### PR TITLE
Add basic admin login and home screen

### DIFF
--- a/JokguApplication/ContentView.swift
+++ b/JokguApplication/ContentView.swift
@@ -1,61 +1,54 @@
-//
-//  ContentView.swift
-//  JokguApplication
-//
-//  Created by In Cho on 8/20/25.
-//
-
 import SwiftUI
-import SwiftData
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var isLoggedIn: Bool = false
+    @State private var loginFailed: Bool = false
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+        if isLoggedIn {
+            HomeView()
+        } else {
+            VStack(spacing: 16) {
+                TextField("Username", text: $username)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding(.horizontal)
+
+                SecureField("Password", text: $password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
+                Button("Login") {
+                    if username == "admin" && password == "admin" {
+                        isLoggedIn = true
+                        loginFailed = false
+                    } else {
+                        loginFailed = true
                     }
                 }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+                .padding(.top)
+
+                if loginFailed {
+                    Text("Invalid credentials")
+                        .foregroundColor(.red)
                 }
             }
-        } detail: {
-            Text("Select an item")
+            .padding()
         }
     }
+}
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
-        }
+struct HomeView: View {
+    var body: some View {
+        Text("Atlanta Jokgu Association")
+            .font(.title)
+            .padding()
     }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
 }

--- a/JokguApplication/JokguApplicationApp.swift
+++ b/JokguApplication/JokguApplicationApp.swift
@@ -6,27 +6,11 @@
 //
 
 import SwiftUI
-import SwiftData
-
 @main
 struct JokguApplicationApp: App {
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Item.self,
-        ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
-        }
-    }()
-
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(sharedModelContainer)
     }
 }


### PR DESCRIPTION
## Summary
- replace initial content view with simple login screen
- navigate to a home view displaying "Atlanta Jokgu Association"
- simplify app entry point by removing unused model container

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a686d704708331ba1792d357d1deaf