### PR TITLE
Add SQLite-backed user management

### DIFF
--- a/JokguApplication/DatabaseManager.swift
+++ b/JokguApplication/DatabaseManager.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SQLite3
+
+class DatabaseManager {
+    static let shared = DatabaseManager()
+    let db: OpaquePointer?
+
+    private init() {
+        var dbPointer: OpaquePointer? = nil
+        let fileURL = try! FileManager.default
+            .url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            .appendingPathComponent("users.sqlite")
+        if sqlite3_open(fileURL.path, &dbPointer) != SQLITE_OK {
+            print("Unable to open database")
+        }
+        db = dbPointer
+        createTables()
+    }
+
+    private func createTables() {
+        let createManagementTable = "CREATE TABLE IF NOT EXISTS management(id INTEGER PRIMARY KEY AUTOINCREMENT, keycode TEXT);"
+        let createMemberTable = "CREATE TABLE IF NOT EXISTS member(id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);"
+        if sqlite3_exec(db, createManagementTable, nil, nil, nil) != SQLITE_OK {
+            print("Could not create management table")
+        }
+        if sqlite3_exec(db, createMemberTable, nil, nil, nil) != SQLITE_OK {
+            print("Could not create member table")
+        }
+    }
+
+    func insertKeyCode(_ keycode: String) {
+        let insertSQL = "INSERT INTO management (keycode) VALUES (?);"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, insertSQL, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, NSString(string: keycode).utf8String, -1, nil)
+            sqlite3_step(statement)
+        }
+        sqlite3_finalize(statement)
+    }
+
+    func userExists(_ username: String) -> Bool {
+        let query = "SELECT 1 FROM member WHERE username = ? LIMIT 1;"
+        var statement: OpaquePointer?
+        var exists = false
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, NSString(string: username).utf8String, -1, nil)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                exists = true
+            }
+        }
+        sqlite3_finalize(statement)
+        return exists
+    }
+
+    func insertUser(username: String, password: String) -> Bool {
+        guard !userExists(username) else { return false }
+        let insertSQL = "INSERT INTO member (username, password) VALUES (?, ?);"
+        var statement: OpaquePointer?
+        var success = false
+        if sqlite3_prepare_v2(db, insertSQL, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, NSString(string: username).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, NSString(string: password).utf8String, -1, nil)
+            if sqlite3_step(statement) == SQLITE_DONE {
+                success = true
+            }
+        }
+        sqlite3_finalize(statement)
+        return success
+    }
+
+    func validateUser(username: String, password: String) -> Bool {
+        let query = "SELECT 1 FROM member WHERE username = ? AND password = ? LIMIT 1;"
+        var statement: OpaquePointer?
+        var valid = false
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, NSString(string: username).utf8String, -1, nil)
+            sqlite3_bind_text(statement, 2, NSString(string: password).utf8String, -1, nil)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                valid = true
+            }
+        }
+        sqlite3_finalize(statement)
+        return valid
+    }
+}
+

--- a/JokguApplication/LoginView.swift
+++ b/JokguApplication/LoginView.swift
@@ -22,7 +22,7 @@ struct LoginView: View {
                 .padding(.horizontal)
 
             Button("Login") {
-                if username == "admin" && password == "admin" {
+                if DatabaseManager.shared.validateUser(username: username, password: password) {
                     isLoggedIn = true
                     loginFailed = false
                 } else {
@@ -49,6 +49,7 @@ struct LoginView: View {
                     .padding(.horizontal)
 
                 Button("Confirm") {
+                    DatabaseManager.shared.insertKeyCode(keyCodeInput)
                     if keyCodeInput == "1234" {
                         showKeyCodePrompt = false
                         keyCodeInput = ""
@@ -68,4 +69,3 @@ struct LoginView: View {
 #Preview {
     LoginView(isLoggedIn: .constant(false))
 }
-

--- a/JokguApplication/RegisterView.swift
+++ b/JokguApplication/RegisterView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
 struct RegisterView: View {
+    @Environment(\.dismiss) var dismiss
     @State private var username: String = ""
     @State private var password: String = ""
+    @State private var message: String? = nil
+    @State private var messageColor: Color = .red
 
     var body: some View {
         VStack(spacing: 16) {
@@ -15,6 +18,31 @@ struct RegisterView: View {
             SecureField("Password", text: $password)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding(.horizontal)
+
+            if let message = message {
+                Text(message)
+                    .foregroundColor(messageColor)
+            }
+
+            HStack {
+                Button("Back") {
+                    dismiss()
+                }
+                Spacer()
+                Button("Create") {
+                    if DatabaseManager.shared.insertUser(username: username, password: password) {
+                        self.message = "User created"
+                        self.messageColor = .green
+                        self.username = ""
+                        self.password = ""
+                    } else {
+                        self.message = "Username already exists"
+                        self.messageColor = .red
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.top)
         }
         .padding()
     }


### PR DESCRIPTION
## Summary
- Add `DatabaseManager` using SQLite to persist key codes and users
- Hook login and registration flows to database, including storing key codes
- Add create and back buttons on registration screen for user creation and dismissal

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68a68d79e3d88331bf800b3c620337d7