### PR TITLE
Limit management edits and add location support

### DIFF
--- a/JokguApplication/LoginView.swift
+++ b/JokguApplication/LoginView.swift
@@ -51,8 +51,8 @@ struct LoginView: View {
                     .padding(.horizontal)
 
                 Button("Confirm") {
-                    _ = DatabaseManager.shared.insertKeyCode(keyCodeInput)
-                    if keyCodeInput == "1234" {
+                    let storedCode = DatabaseManager.shared.fetchKeyCodes().first?.code ?? ""
+                    if keyCodeInput == storedCode {
                         showKeyCodePrompt = false
                         keyCodeInput = ""
                         showRegisterView = true

--- a/JokguApplication/ManagementView.swift
+++ b/JokguApplication/ManagementView.swift
@@ -1,40 +1,31 @@
 import SwiftUI
 
 struct ManagementView: View {
-    @State private var keyCodes: [KeyCode] = []
-    @State private var newCode: String = ""
+    @Environment(\.dismiss) var dismiss
+    @State private var keyCode = KeyCode(id: 0, code: "", location: "")
 
     var body: some View {
         NavigationView {
-            VStack {
-                List {
-                    ForEach($keyCodes) { $item in
-                        TextField("Keycode", text: $item.code, onCommit: {
-                            DatabaseManager.shared.updateKeyCode(id: item.id, code: item.code)
-                        })
-                    }
-                    .onDelete { indexSet in
-                        for index in indexSet {
-                            let id = keyCodes[index].id
-                            DatabaseManager.shared.deleteKeyCode(id: id)
-                        }
-                        keyCodes.remove(atOffsets: indexSet)
-                    }
-                }
+            VStack(spacing: 16) {
+                TextField("Keycode", text: $keyCode.code, onCommit: {
+                    DatabaseManager.shared.updateManagement(id: keyCode.id, code: keyCode.code, location: keyCode.location)
+                })
+                .textFieldStyle(RoundedBorderTextFieldStyle())
 
-                HStack {
-                    TextField("New keycode", text: $newCode)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                    Button("Add") {
-                        if DatabaseManager.shared.insertKeyCode(newCode) {
-                            loadData()
-                            newCode = ""
-                        }
-                    }
-                }
-                .padding()
+                TextField("Location", text: $keyCode.location, onCommit: {
+                    DatabaseManager.shared.updateManagement(id: keyCode.id, code: keyCode.code, location: keyCode.location)
+                })
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                Spacer()
             }
+            .padding()
             .navigationTitle("Management")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
             .onAppear {
                 loadData()
             }
@@ -42,7 +33,9 @@ struct ManagementView: View {
     }
 
     private func loadData() {
-        keyCodes = DatabaseManager.shared.fetchKeyCodes()
+        if let item = DatabaseManager.shared.fetchKeyCodes().first {
+            keyCode = item
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add location column to management table and ensure a single default keycode record
- restrict management view to edit existing keycode and location with a back button
- verify registration keycode against stored value without inserting new records

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a75d4346d083318ae621a65b871ed2