### PR TITLE
Add members list view and timed authentication alerts

### DIFF
--- a/JokguApplication/DatabaseManager.swift
+++ b/JokguApplication/DatabaseManager.swift
@@ -7,6 +7,13 @@ struct KeyCode: Identifiable {
     var location: String
 }
 
+struct Member: Identifiable {
+    let id: Int
+    var username: String
+    var password: String
+    var permit: Int
+}
+
 class DatabaseManager {
     static let shared = DatabaseManager()
     let db: OpaquePointer?
@@ -92,6 +99,29 @@ class DatabaseManager {
         }
         sqlite3_finalize(statement)
         return permit
+    }
+
+    func fetchMembers() -> [Member] {
+        let query = "SELECT id, username, password, permit FROM member;"
+        var statement: OpaquePointer?
+        var items: [Member] = []
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let id = Int(sqlite3_column_int(statement, 0))
+                var username = ""
+                if let uString = sqlite3_column_text(statement, 1) {
+                    username = String(cString: uString)
+                }
+                var password = ""
+                if let pString = sqlite3_column_text(statement, 2) {
+                    password = String(cString: pString)
+                }
+                let permit = Int(sqlite3_column_int(statement, 3))
+                items.append(Member(id: id, username: username, password: password, permit: permit))
+            }
+        }
+        sqlite3_finalize(statement)
+        return items
     }
 
     func fetchKeyCodes() -> [KeyCode] {

--- a/JokguApplication/HomeView.swift
+++ b/JokguApplication/HomeView.swift
@@ -4,12 +4,21 @@ struct HomeView: View {
     @Binding var isLoggedIn: Bool
     @Binding var userPermit: Int
     @State private var showManagement = false
+    @State private var showMembers = false
 
     var body: some View {
         VStack {
             Text("Atlanta Jokgu Association")
                 .font(.title)
                 .padding()
+
+            Button("Members") {
+                showMembers = true
+            }
+            .padding()
+            .sheet(isPresented: $showMembers) {
+                MemberView()
+            }
 
             if userPermit > 0 {
                 Button("Management") {

--- a/JokguApplication/LoginView.swift
+++ b/JokguApplication/LoginView.swift
@@ -29,6 +29,9 @@ struct LoginView: View {
                     userPermit = permit
                 } else {
                     loginFailed = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        loginFailed = false
+                    }
                 }
             }
             .padding(.top)

--- a/JokguApplication/MemberView.swift
+++ b/JokguApplication/MemberView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct MemberView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var members: [Member] = []
+
+    var body: some View {
+        NavigationView {
+            List(members) { member in
+                VStack(alignment: .leading) {
+                    Text("ID: \(member.id)")
+                    Text("Username: \(member.username)")
+                    Text("Password: \(member.password)")
+                }
+            }
+            .navigationTitle("Members")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+            .onAppear {
+                members = DatabaseManager.shared.fetchMembers()
+            }
+        }
+    }
+}
+
+#Preview {
+    MemberView()
+}
+

--- a/JokguApplication/RegisterView.swift
+++ b/JokguApplication/RegisterView.swift
@@ -31,16 +31,13 @@ struct RegisterView: View {
                 Spacer()
                 Button("Create") {
                     if DatabaseManager.shared.userExists(username) {
-                        self.message = "Username already exists"
-                        self.messageColor = .red
+                        showMessage("Username already exists", color: .red)
                     } else if DatabaseManager.shared.insertUser(username: username, password: password) {
-                        self.message = "User created"
-                        self.messageColor = .green
+                        showMessage("User created", color: .green)
                         self.username = ""
                         self.password = ""
                     } else {
-                        self.message = "Unable to create user"
-                        self.messageColor = .red
+                        showMessage("Unable to create user", color: .red)
                     }
                 }
             }
@@ -48,6 +45,14 @@ struct RegisterView: View {
             .padding(.top)
         }
         .padding()
+    }
+
+    private func showMessage(_ text: String, color: Color) {
+        message = text
+        messageColor = color
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            message = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- auto-dismiss login and registration alerts after 3 seconds
- add Members button on Home and new MemberView to list users
- extend DatabaseManager to fetch members for display

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a763d27bb88331951e20bc9425a97b