### PR TITLE
Improve key code prompt and management queries

### DIFF
--- a/JokguApplication/DatabaseManager.swift
+++ b/JokguApplication/DatabaseManager.swift
@@ -124,7 +124,22 @@ class DatabaseManager {
         return items
     }
 
-    func fetchKeyCodes() -> [KeyCode] {
+    func fetchKeyCode() -> String? {
+        let query = "SELECT keycode FROM management LIMIT 1;"
+        var statement: OpaquePointer?
+        var code: String? = nil
+        if sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK {
+            if sqlite3_step(statement) == SQLITE_ROW {
+                if let cString = sqlite3_column_text(statement, 0) {
+                    code = String(cString: cString)
+                }
+            }
+        }
+        sqlite3_finalize(statement)
+        return code
+    }
+
+    func fetchManagementData() -> [KeyCode] {
         let query = "SELECT id, keycode, location FROM management;"
         var statement: OpaquePointer?
         var items: [KeyCode] = []

--- a/JokguApplication/LoginView.swift
+++ b/JokguApplication/LoginView.swift
@@ -53,12 +53,21 @@ struct LoginView: View {
                     .keyboardType(.numberPad)
                     .padding(.horizontal)
 
-                Button("Confirm") {
-                    let storedCode = DatabaseManager.shared.fetchKeyCodes().first?.code ?? ""
-                    if keyCodeInput == storedCode {
+                HStack {
+                    Button("Cancel") {
                         showKeyCodePrompt = false
                         keyCodeInput = ""
-                        showRegisterView = true
+                    }
+
+                    Spacer()
+
+                    Button("Confirm") {
+                        let storedCode = DatabaseManager.shared.fetchKeyCode() ?? ""
+                        if keyCodeInput == storedCode {
+                            showKeyCodePrompt = false
+                            keyCodeInput = ""
+                            showRegisterView = true
+                        }
                     }
                 }
                 .padding(.top)

--- a/JokguApplication/ManagementView.swift
+++ b/JokguApplication/ManagementView.swift
@@ -41,7 +41,7 @@ struct ManagementView: View {
     }
 
     private func loadData() {
-        if let item = DatabaseManager.shared.fetchKeyCodes().first {
+        if let item = DatabaseManager.shared.fetchManagementData().first {
             keyCode = item
             originalKeyCode = item
         }


### PR DESCRIPTION
## Summary
- Allow cancelling out of key code verification prompt
- Split key code lookup from management data retrieval
- Use dedicated management query when loading management view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ec12a588331a37340d1c23f7b91