### PR TITLE
Expand registration with user details

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct RegisterView: View {
     @Environment(\.dismiss) var dismiss
+    @State private var firstName: String = ""
+    @State private var lastName: String = ""
+    @State private var phoneNumber: String = ""
+    @State private var dob: Date = Date()
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var message: String? = nil
@@ -9,6 +13,24 @@ struct RegisterView: View {
 
     var body: some View {
         VStack(spacing: 16) {
+            TextField("First Name", text: $firstName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
+            TextField("Last Name", text: $lastName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
+            TextField("Phone Number", text: $phoneNumber)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .keyboardType(.phonePad)
+                .padding(.horizontal)
+
+            DatePicker("Date of Birth", selection: $dob, displayedComponents: .date)
+                .datePickerStyle(.compact)
+                .environment(\.locale, Locale(identifier: "en_GB"))
+                .padding(.horizontal)
+
             TextField("Username", text: $username)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .textInputAutocapitalization(.never)
@@ -32,8 +54,12 @@ struct RegisterView: View {
                 Button("Create") {
                     if DatabaseManager.shared.userExists(username) {
                         showMessage("Username already exists", color: .red)
-                    } else if DatabaseManager.shared.insertUser(username: username, password: password) {
+                    } else if DatabaseManager.shared.insertUser(username: username, password: password, firstName: firstName, lastName: lastName, phoneNumber: phoneNumber, dob: dateFormatter.string(from: dob)) {
                         showMessage("User created", color: .green)
+                        self.firstName = ""
+                        self.lastName = ""
+                        self.phoneNumber = ""
+                        self.dob = Date()
                         self.username = ""
                         self.password = ""
                     } else {
@@ -53,6 +79,12 @@ struct RegisterView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             message = nil
         }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "dd/MM/yyyy"
+        return formatter
     }
 }
 


### PR DESCRIPTION
## Summary
- capture first name, last name, phone, and date of birth during registration
- store new user details with default attendance

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a77aefff308331804fdb65b7e36a0a