### PR TITLE
Hash and hide stored passwords

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -10,7 +10,6 @@ struct MemberView: View {
                 VStack(alignment: .leading) {
                     Text("ID: \(member.id)")
                     Text("Username: \(member.username)")
-                    Text("Password: \(member.password)")
                 }
             }
             .navigationTitle("Members")


### PR DESCRIPTION
## Summary
- hash passwords using SHA256 before storing and validating
- remove password field from member list view

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project JokguApplication.xcodeproj -scheme JokguApplication -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7825ef9f88331895611928b0a148c