### PR TITLE
Format phone input and improve member list

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -25,6 +25,9 @@ struct RegisterView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .keyboardType(.phonePad)
                 .padding(.horizontal)
+                .onChange(of: phoneNumber) { newValue in
+                    phoneNumber = formatPhoneNumber(newValue)
+                }
 
             DatePicker("Date of Birth", selection: Binding(
                 get: { dob ?? Date() },
@@ -72,6 +75,7 @@ struct RegisterView: View {
                         self.dob = nil
                         self.username = ""
                         self.password = ""
+                        dismiss()
                     } else {
                         showMessage("Unable to create user", color: .red)
                     }
@@ -95,6 +99,24 @@ struct RegisterView: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "dd/MM/yyyy"
         return formatter
+    }
+
+    private func formatPhoneNumber(_ number: String) -> String {
+        let digits = number.filter { $0.isNumber }
+        let limited = String(digits.prefix(10))
+        let area = limited.prefix(3)
+        let middle = limited.dropFirst(3).prefix(3)
+        let last = limited.dropFirst(6)
+        var result = ""
+        if !area.isEmpty {
+            result += "(" + area
+            if area.count == 3 { result += ")" }
+        }
+        result += middle
+        if !last.isEmpty {
+            result += "-" + last
+        }
+        return result
     }
 }
 

--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -8,8 +8,10 @@ struct MemberView: View {
         NavigationView {
             List(members) { member in
                 VStack(alignment: .leading) {
-                    Text("ID: \(member.id)")
-                    Text("Username: \(member.username)")
+                    Text("\(member.lastName) \(member.firstName)")
+                    Text("DOB: \(member.dob)")
+                    Text("Phone: \(member.phoneNumber)")
+                    Text("Attendance: \(member.attendance)")
                 }
             }
             .navigationTitle("Members")


### PR DESCRIPTION
## Summary
- Format phone number input as (xxx)xxx-xxxx and return to login after successful registration
- Show member name, DOB, phone number, and attendance in member list

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a88283e778833196da8122d6480824