### PR TITLE
refactor: update onChange closures

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -16,7 +16,7 @@ struct LoginView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
-                .onChange(of: username) { newValue in
+                .onChange(of: username) { _, newValue in
                     username = newValue.uppercased().filter { $0.isLetter }
                 }
                 .padding(.horizontal)

--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -25,7 +25,7 @@ struct RegisterView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .keyboardType(.phonePad)
                 .padding(.horizontal)
-                .onChange(of: phoneNumber) { newValue in
+                .onChange(of: phoneNumber) { _, newValue in
                     phoneNumber = formatPhoneNumber(newValue)
                 }
 
@@ -41,7 +41,7 @@ struct RegisterView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
-                .onChange(of: username) { newValue in
+                .onChange(of: username) { _, newValue in
                     username = newValue.uppercased().filter { $0.isLetter }
                 }
                 .padding(.horizontal)


### PR DESCRIPTION
## Summary
- replace deprecated `onChange(of:perform:)` usages with new two-parameter closure

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project JokguApplication.xcodeproj -scheme JokguApplication -quiet build` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a8875cf2688331a0d82fc60e163299