### PR TITLE
Add profile editing and password verification

### DIFF
--- a/JokguApplication/Core/ContentView.swift
+++ b/JokguApplication/Core/ContentView.swift
@@ -3,12 +3,13 @@ import SwiftUI
 struct ContentView: View {
     @State private var isLoggedIn: Bool = false
     @State private var userPermit: Int = 0
+    @State private var username: String = ""
 
     var body: some View {
         if isLoggedIn {
-            HomeView(isLoggedIn: $isLoggedIn, userPermit: $userPermit)
+            HomeView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, username: $username)
         } else {
-            LoginView(isLoggedIn: $isLoggedIn, userPermit: $userPermit)
+            LoginView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, loggedInUser: $username)
         }
     }
 }

--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 struct HomeView: View {
     @Binding var isLoggedIn: Bool
     @Binding var userPermit: Int
+    @Binding var username: String
     @State private var showManagement = false
     @State private var showMembers = false
+    @State private var showProfile = false
 
     var body: some View {
         VStack {
@@ -20,6 +22,14 @@ struct HomeView: View {
                 MemberView()
             }
 
+            Button("Profile") {
+                showProfile = true
+            }
+            .padding()
+            .sheet(isPresented: $showProfile) {
+                ProfileView(username: username)
+            }
+
             if userPermit > 0 {
                 Button("Management") {
                     showManagement = true
@@ -31,6 +41,7 @@ struct HomeView: View {
             }
 
             Button("Logout") {
+                username = ""
                 isLoggedIn = false
             }
             .padding()
@@ -39,5 +50,5 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(isLoggedIn: .constant(true), userPermit: .constant(1))
+    HomeView(isLoggedIn: .constant(true), userPermit: .constant(1), username: .constant("USER"))
 }

--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct LoginView: View {
     @Binding var isLoggedIn: Bool
     @Binding var userPermit: Int
+    @Binding var loggedInUser: String
     @State private var username: String = ""
     @State private var password: String = ""
     @State private var loginFailed: Bool = false
@@ -28,6 +29,7 @@ struct LoginView: View {
             Button("Login") {
                 let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
                 if let permit = DatabaseManager.shared.validateUser(username: trimmedUser, password: password) {
+                    loggedInUser = trimmedUser
                     isLoggedIn = true
                     loginFailed = false
                     userPermit = permit
@@ -85,5 +87,5 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView(isLoggedIn: .constant(false), userPermit: .constant(0))
+    LoginView(isLoggedIn: .constant(false), userPermit: .constant(0), loggedInUser: .constant(""))
 }

--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -8,6 +8,7 @@ struct RegisterView: View {
     @State private var dob: Date? = nil
     @State private var username: String = ""
     @State private var password: String = ""
+    @State private var confirmPassword: String = ""
     @State private var message: String? = nil
     @State private var messageColor: Color = .red
 
@@ -50,6 +51,10 @@ struct RegisterView: View {
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding(.horizontal)
 
+            SecureField("Confirm Password", text: $confirmPassword)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
             if let message = message {
                 Text(message)
                     .foregroundColor(messageColor)
@@ -66,8 +71,10 @@ struct RegisterView: View {
                     let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
                     let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
 
-                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty || dob == nil {
+                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty || confirmPassword.isEmpty || dob == nil {
                         showMessage("All fields are required", color: .red)
+                    } else if password != confirmPassword {
+                        showMessage("Passwords do not match", color: .red)
                     } else if !trimmedUser.allSatisfy({ $0.isLetter }) {
                         showMessage("Username must contain letters only", color: .red)
                     } else if DatabaseManager.shared.userExists(trimmedUser) {
@@ -80,6 +87,7 @@ struct RegisterView: View {
                         self.dob = nil
                         self.username = ""
                         self.password = ""
+                        self.confirmPassword = ""
                         dismiss()
                     } else {
                         showMessage("Unable to create user", color: .red)

--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @Environment(\.dismiss) var dismiss
+    let username: String
+    @State private var firstName: String = ""
+    @State private var lastName: String = ""
+    @State private var phoneNumber: String = ""
+    @State private var dob: Date? = nil
+    @State private var currentPassword: String = ""
+    @State private var newPassword: String = ""
+    @State private var confirmPassword: String = ""
+    @State private var message: String? = nil
+    @State private var messageColor: Color = .red
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 16) {
+                    TextField("First Name", text: $firstName)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.horizontal)
+
+                    TextField("Last Name", text: $lastName)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.horizontal)
+
+                    TextField("Phone Number", text: $phoneNumber)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .keyboardType(.phonePad)
+                        .padding(.horizontal)
+                        .onChange(of: phoneNumber) { _, newValue in
+                            phoneNumber = formatPhoneNumber(newValue)
+                        }
+
+                    DatePicker("Date of Birth", selection: Binding(
+                        get: { dob ?? Date() },
+                        set: { dob = $0 }
+                    ), displayedComponents: .date)
+                        .datePickerStyle(.compact)
+                        .environment(\.locale, Locale(identifier: "en_US"))
+                        .padding(.horizontal)
+
+                    Button("Save Info") {
+                        let trimmedFirst = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedLast = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                        if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || dob == nil {
+                            showMessage("All fields are required", color: .red)
+                        } else if DatabaseManager.shared.updateUser(username: username, firstName: trimmedFirst, lastName: trimmedLast, phoneNumber: trimmedPhone, dob: dateFormatter.string(from: dob!)) {
+                            showMessage("Information updated", color: .green)
+                        } else {
+                            showMessage("Unable to update information", color: .red)
+                        }
+                    }
+                    .padding(.top)
+
+                    Divider().padding(.vertical)
+
+                    SecureField("Current Password", text: $currentPassword)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.horizontal)
+
+                    SecureField("New Password", text: $newPassword)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.horizontal)
+
+                    SecureField("Confirm Password", text: $confirmPassword)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .padding(.horizontal)
+
+                    Button("Update Password") {
+                        if currentPassword.isEmpty || newPassword.isEmpty || confirmPassword.isEmpty {
+                            showMessage("All password fields are required", color: .red)
+                        } else if newPassword != confirmPassword {
+                            showMessage("Passwords do not match", color: .red)
+                        } else if DatabaseManager.shared.updatePassword(username: username, currentPassword: currentPassword, newPassword: newPassword) {
+                            showMessage("Password updated", color: .green)
+                            currentPassword = ""
+                            newPassword = ""
+                            confirmPassword = ""
+                        } else {
+                            showMessage("Current password incorrect", color: .red)
+                        }
+                    }
+                    .padding(.top)
+
+                    if let message = message {
+                        Text(message)
+                            .foregroundColor(messageColor)
+                    }
+                }
+                .padding(.bottom)
+            }
+            .navigationTitle("Profile")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+            .onAppear {
+                if let member = DatabaseManager.shared.fetchUser(username: username) {
+                    firstName = member.firstName
+                    lastName = member.lastName
+                    phoneNumber = member.phoneNumber
+                    dob = dateFormatter.date(from: member.dob)
+                }
+            }
+        }
+    }
+
+    private func showMessage(_ text: String, color: Color) {
+        message = text
+        messageColor = color
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            message = nil
+        }
+    }
+
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd/yyyy"
+        return formatter
+    }
+
+    private func formatPhoneNumber(_ number: String) -> String {
+        let digits = number.filter { $0.isNumber }
+        let limited = String(digits.prefix(10))
+        let area = limited.prefix(3)
+        let middle = limited.dropFirst(3).prefix(3)
+        let last = limited.dropFirst(6)
+        var result = ""
+        if !area.isEmpty {
+            result += "(" + area
+            if area.count == 3 { result += ")" }
+        }
+        result += middle
+        if !last.isEmpty {
+            result += "-" + last
+        }
+        return result
+    }
+}
+
+#Preview {
+    ProfileView(username: "USER")
+}
+


### PR DESCRIPTION
## Summary
- Add username tracking through login and home views
- Introduce profile screen for editing personal info and password
- Require password confirmation during registration and password changes

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a88bc03b608331a6654bf78e887d89