### PR TITLE
Improve confirm password validation

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -71,8 +71,10 @@ struct RegisterView: View {
                     let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
                     let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
 
-                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty || confirmPassword.isEmpty || dob == nil {
+                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty || dob == nil {
                         showMessage("All fields are required", color: .red)
+                    } else if confirmPassword.isEmpty {
+                        showMessage("Please confirm your password", color: .red)
                     } else if password != confirmPassword {
                         showMessage("Passwords do not match", color: .red)
                     } else if !trimmedUser.allSatisfy({ $0.isLetter }) {

--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -71,8 +71,10 @@ struct ProfileView: View {
                         .padding(.horizontal)
 
                     Button("Update Password") {
-                        if currentPassword.isEmpty || newPassword.isEmpty || confirmPassword.isEmpty {
-                            showMessage("All password fields are required", color: .red)
+                        if currentPassword.isEmpty || newPassword.isEmpty {
+                            showMessage("Current and new passwords are required", color: .red)
+                        } else if confirmPassword.isEmpty {
+                            showMessage("Please confirm your new password", color: .red)
                         } else if newPassword != confirmPassword {
                             showMessage("Passwords do not match", color: .red)
                         } else if DatabaseManager.shared.updatePassword(username: username, currentPassword: currentPassword, newPassword: newPassword) {


### PR DESCRIPTION
## Summary
- Show a dedicated "Please confirm your password" message during registration
- Display a distinct confirm-password warning when updating passwords in the profile view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e862abc8331af9a75267ec5518a