### PR TITLE
Show specific message for missing date of birth

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -71,8 +71,10 @@ struct RegisterView: View {
                     let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
                     let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
 
-                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty || dob == nil {
+                    if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || trimmedUser.isEmpty || password.isEmpty {
                         showMessage("All fields are required", color: .red)
+                    } else if dob == nil {
+                        showMessage("Date of birth is required", color: .red)
                     } else if confirmPassword.isEmpty {
                         showMessage("Please confirm your password", color: .red)
                     } else if password != confirmPassword {


### PR DESCRIPTION
## Summary
- refine registration validation to explicitly require a date of birth

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8939a5b0483318b3bac149f88c081