### PR TITLE
Add default profile picture field to register view

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import PhotosUI
+import UIKit
 
 struct RegisterView: View {
     @Environment(\.dismiss) var dismiss
@@ -11,9 +13,20 @@ struct RegisterView: View {
     @State private var confirmPassword: String = ""
     @State private var message: String? = nil
     @State private var messageColor: Color = .red
+    @State private var picture: Image = Image(systemName: "person.crop.circle")
+    @State private var pictureItem: PhotosPickerItem? = nil
 
     var body: some View {
         VStack(spacing: 16) {
+            PhotosPicker(selection: $pictureItem, matching: .images) {
+                picture
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 120, height: 120)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color.gray, lineWidth: 1))
+            }
+            .padding(.bottom)
             TextField("First Name", text: $firstName)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding(.horizontal)
@@ -102,6 +115,16 @@ struct RegisterView: View {
             .padding(.top)
         }
         .padding()
+        .onChange(of: pictureItem) { _, newValue in
+            if let newValue {
+                Task {
+                    if let data = try? await newValue.loadTransferable(type: Data.self),
+                       let uiImage = UIImage(data: data) {
+                        picture = Image(uiImage: uiImage)
+                    }
+                }
+            }
+        }
     }
 
     private func showMessage(_ text: String, color: Color) {


### PR DESCRIPTION
## Summary
- show a default profile image on the register view using an SF Symbol placeholder
- allow user to select a different picture using PhotosPicker

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a89c227b9483319e435dbf4a627655