### PR TITLE
Add profile picture support

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 struct MemberView: View {
     @Environment(\.dismiss) var dismiss
@@ -7,11 +8,27 @@ struct MemberView: View {
     var body: some View {
         NavigationView {
             List(members) { member in
-                VStack(alignment: .leading) {
-                    Text("\(member.lastName) \(member.firstName)")
-                    Text("DOB: \(member.dob)")
-                    Text("Phone: \(member.phoneNumber)")
-                    Text("Attendance: \(member.attendance)")
+                HStack(alignment: .top) {
+                    if let data = member.picture,
+                       let uiImage = UIImage(data: data) {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 60, height: 60)
+                            .clipShape(Circle())
+                    } else {
+                        Image("default-profile")
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 60, height: 60)
+                            .clipShape(Circle())
+                    }
+                    VStack(alignment: .leading) {
+                        Text("\(member.lastName) \(member.firstName)")
+                        Text("DOB: \(member.dob)")
+                        Text("Phone: \(member.phoneNumber)")
+                        Text("Attendance: \(member.attendance)")
+                    }
                 }
             }
             .navigationTitle("Members")


### PR DESCRIPTION
## Summary
- allow members to choose a profile picture during registration with a default avatar
- show member photos in member list
- enable editing of profile picture in profile view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b45f49b48331b7871ee27e9caae9