### PR TITLE
Display welcome message and location on home screen

### DIFF
--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -17,20 +17,23 @@ struct HomeView: View {
                 .font(.title)
                 .padding()
 
-            Text(management.welcome)
+            VStack(spacing: 8) {
+                Text(management.welcome)
 
-            Button(action: { showAddressPrompt = true }) {
-                Text(management.address)
-                    .foregroundColor(.blue)
-                    .underline()
-            }
-            .disabled(management.address.isEmpty)
-            .alert("Open in Maps?", isPresented: $showAddressPrompt) {
-                Button("Open") {
-                    openInMaps(address: management.address)
+                Button(action: { showAddressPrompt = true }) {
+                    Text(management.address)
+                        .foregroundColor(.blue)
+                        .underline()
                 }
-                Button("Cancel", role: .cancel) {}
+                .disabled(management.address.isEmpty)
+                .alert("Open in Maps?", isPresented: $showAddressPrompt) {
+                    Button("Open") {
+                        openInMaps(address: management.address)
+                    }
+                    Button("Cancel", role: .cancel) {}
+                }
             }
+            .padding(.bottom)
 
             Text(management.notification)
                 .padding(.vertical)


### PR DESCRIPTION
## Summary
- Group welcome message and location into a single section on HomeView for easier access

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme JokguApplication -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c737bb308331a12029759f2a30bc