### PR TITLE
Silence unused withUnsafeBytes warnings

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -101,7 +101,7 @@ class DatabaseManager {
             sqlite3_bind_text(statement, 5, NSString(string: phoneNumber).utf8String, -1, nil)
             sqlite3_bind_text(statement, 6, NSString(string: dob).utf8String, -1, nil)
             if let picture = picture {
-                picture.withUnsafeBytes { bytes in
+                _ = picture.withUnsafeBytes { bytes in
                     sqlite3_bind_blob(statement, 7, bytes.baseAddress, Int32(picture.count), nil)
                 }
             } else {
@@ -226,7 +226,7 @@ class DatabaseManager {
             sqlite3_bind_text(statement, 3, NSString(string: phoneNumber).utf8String, -1, nil)
             sqlite3_bind_text(statement, 4, NSString(string: dob).utf8String, -1, nil)
             if let picture = picture {
-                picture.withUnsafeBytes { bytes in
+                _ = picture.withUnsafeBytes { bytes in
                     sqlite3_bind_blob(statement, 5, bytes.baseAddress, Int32(picture.count), nil)
                 }
             } else {


### PR DESCRIPTION
## Summary
- avoid unused results from `withUnsafeBytes` when binding images to SQLite

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c8ea5c148331bf69f070e2882fa4