### PR TITLE
Add Venmo payment view

### DIFF
--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -7,6 +7,7 @@ struct HomeView: View {
     @State private var showManagement = false
     @State private var showMembers = false
     @State private var showProfile = false
+    @State private var showPayment = false
     @State private var management = KeyCode(id: 0, code: "", address: "", welcome: "", youtube: nil, notification: "")
 
     var body: some View {
@@ -33,6 +34,14 @@ struct HomeView: View {
             .padding()
             .sheet(isPresented: $showProfile) {
                 ProfileView(username: username)
+            }
+
+            Button("Payment") {
+                showPayment = true
+            }
+            .padding()
+            .sheet(isPresented: $showPayment) {
+                PaymentView()
             }
 
             if userPermit > 0 {

--- a/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct PaymentView: View {
+    @Environment(\.dismiss) var dismiss
+
+    private let venmoURL = URL(string: "https://venmo.com/atlanta-jokgu")!
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Text("Support the club via Venmo")
+                    .font(.title3)
+                Link("Pay with Venmo", destination: venmoURL)
+                    .padding()
+            }
+            .navigationTitle("Payment")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PaymentView()
+}


### PR DESCRIPTION
## Summary
- add dedicated PaymentView linking to club's Venmo account
- expose Payment button on HomeView for all users

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d27e12b0833190dd442a210a1e39