### PR TITLE
Display membership table on management view

### DIFF
--- a/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
@@ -1,72 +1,76 @@
 import SwiftUI
 
 struct ManagementView: View {
-    var onSave: (() -> Void)? = nil
     @Environment(\.dismiss) var dismiss
-    @State private var keyCode = KeyCode(id: 0, code: "", address: "", welcome: "", youtube: nil, notification: "")
-    @State private var originalKeyCode = KeyCode(id: 0, code: "", address: "", welcome: "", youtube: nil, notification: "")
-
-    private var hasChanges: Bool {
-        keyCode.code != originalKeyCode.code ||
-        keyCode.address != originalKeyCode.address ||
-        keyCode.welcome != originalKeyCode.welcome ||
-        keyCode.youtube != originalKeyCode.youtube ||
-        keyCode.notification != originalKeyCode.notification
-    }
+    @State private var members: [Member] = []
+    @State private var userFields: [String: [Int]] = [:]
+    private let months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
 
     var body: some View {
         NavigationView {
-            VStack(spacing: 16) {
-                TextField("Keycode", text: $keyCode.code)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                TextField("Address", text: $keyCode.address)
-                    .textContentType(.fullStreetAddress)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                TextField("Welcome", text: $keyCode.welcome)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                TextField("Youtube", text: Binding(
-                    get: { keyCode.youtube?.absoluteString ?? "" },
-                    set: { keyCode.youtube = URL(string: $0.lowercased()) }
-                ))
-                .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                TextField("Notification", text: $keyCode.notification)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                Spacer()
+            ScrollView([.vertical, .horizontal]) {
+                VStack(alignment: .leading, spacing: 0) {
+                    headerRow()
+                    ForEach(members) { member in
+                        rowView(for: member)
+                    }
+                }
             }
-            .padding()
             .navigationTitle("Management")
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Back") { dismiss() }
                 }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Save") {
-                        DatabaseManager.shared.updateManagement(id: keyCode.id, code: keyCode.code, address: keyCode.address, welcome: keyCode.welcome, youtube: keyCode.youtube, notification: keyCode.notification)
-                        originalKeyCode = keyCode
-                        onSave?()
-                    }
-                    .disabled(!hasChanges)
-                }
             }
-            .onAppear {
-                loadData()
+            .onAppear { loadData() }
+        }
+    }
+
+    private func headerRow() -> some View {
+        HStack(spacing: 0) {
+            Text("")
+                .frame(width: 120, height: 40)
+                .border(Color.gray)
+            ForEach(months, id: \.self) { month in
+                Text(month)
+                    .frame(width: 60, height: 40)
+                    .background(Color.gray.opacity(0.2))
+                    .border(Color.gray)
+            }
+        }
+    }
+
+    private func rowView(for member: Member) -> some View {
+        let fields = userFields[member.username] ?? []
+        return HStack(spacing: 0) {
+            Text("\(member.lastName) \(member.firstName)")
+                .frame(width: 120, height: 40, alignment: .leading)
+                .border(Color.gray)
+            ForEach(0..<12, id: \.self) { index in
+                let value = index < fields.count ? fields[index] : 0
+                Text(value > 0 ? "\(value)" : "-")
+                    .frame(width: 60, height: 40)
+                    .background(value > 0 ? Color.green.opacity(0.3) : Color.clear)
+                    .border(Color.gray)
             }
         }
     }
 
     private func loadData() {
-        if let item = DatabaseManager.shared.fetchManagementData().first {
-            keyCode = item
-            originalKeyCode = item
+        members = DatabaseManager.shared.fetchMembers()
+        var dict: [String: [Int]] = [:]
+        for member in members {
+            if let values = DatabaseManager.shared.fetchUserFields(username: member.username) {
+                dict[member.username] = values
+            } else {
+                dict[member.username] = []
+            }
         }
+        userFields = dict
     }
 }
 
 #Preview {
     ManagementView()
 }
+


### PR DESCRIPTION
## Summary
- Replace existing management editor with table view showing monthly membership entries
- Fetch members and `user_fields` values to render a scrollable grid

## Testing
- `xcodebuild test -scheme JokguApplication -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8de1d73808331aace055d69fa5ce0