### PR TITLE
Add PayStatusView and adjust management navigation

### DIFF
--- a/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
@@ -2,19 +2,14 @@ import SwiftUI
 
 struct ManagementView: View {
     @Environment(\.dismiss) var dismiss
-    @State private var members: [Member] = []
-    @State private var userFields: [String: [Int]] = [:]
-    private let months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+    @State private var showPayStatus = false
 
     var body: some View {
         NavigationView {
-            ScrollView([.vertical, .horizontal]) {
-                VStack(alignment: .leading, spacing: 0) {
-                    headerRow()
-                    ForEach(members) { member in
-                        rowView(for: member)
-                    }
-                }
+            VStack {
+                Button("Membership") { showPayStatus = true }
+                    .padding()
+                Spacer()
             }
             .navigationTitle("Management")
             .toolbar {
@@ -22,55 +17,13 @@ struct ManagementView: View {
                     Button("Back") { dismiss() }
                 }
             }
-            .onAppear { loadData() }
         }
-    }
-
-    private func headerRow() -> some View {
-        HStack(spacing: 0) {
-            Text("")
-                .frame(width: 120, height: 40)
-                .border(Color.gray)
-            ForEach(months, id: \.self) { month in
-                Text(month)
-                    .frame(width: 60, height: 40)
-                    .background(Color.gray.opacity(0.2))
-                    .border(Color.gray)
-            }
+        .sheet(isPresented: $showPayStatus) {
+            PayStatusView()
         }
-    }
-
-    private func rowView(for member: Member) -> some View {
-        let fields = userFields[member.username] ?? []
-        return HStack(spacing: 0) {
-            Text("\(member.lastName) \(member.firstName)")
-                .frame(width: 120, height: 40, alignment: .leading)
-                .border(Color.gray)
-            ForEach(0..<12, id: \.self) { index in
-                let value = index < fields.count ? fields[index] : 0
-                Text(value > 0 ? "\(value)" : "-")
-                    .frame(width: 60, height: 40)
-                    .background(value > 0 ? Color.green.opacity(0.3) : Color.clear)
-                    .border(Color.gray)
-            }
-        }
-    }
-
-    private func loadData() {
-        members = DatabaseManager.shared.fetchMembers()
-        var dict: [String: [Int]] = [:]
-        for member in members {
-            if let values = DatabaseManager.shared.fetchUserFields(username: member.username) {
-                dict[member.username] = values
-            } else {
-                dict[member.username] = []
-            }
-        }
-        userFields = dict
     }
 }
 
 #Preview {
     ManagementView()
 }
-

--- a/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct PayStatusView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var members: [Member] = []
+    @State private var userFields: [String: [Int]] = [:]
+    private let months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+
+    var body: some View {
+        NavigationView {
+            ScrollView([.vertical, .horizontal]) {
+                VStack(alignment: .leading, spacing: 0) {
+                    headerRow()
+                    ForEach(0..<months.count, id: \.self) { index in
+                        rowView(for: index)
+                    }
+                }
+            }
+            .navigationTitle("Membership")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Back") { dismiss() }
+                }
+            }
+            .onAppear { loadData() }
+        }
+    }
+
+    private func headerRow() -> some View {
+        HStack(spacing: 0) {
+            Text("")
+                .frame(width: 80, height: 40)
+                .border(Color.gray)
+            ForEach(members) { member in
+                Text(member.username)
+                    .frame(width: 120, height: 40)
+                    .background(Color.gray.opacity(0.2))
+                    .border(Color.gray)
+            }
+        }
+    }
+
+    private func rowView(for monthIndex: Int) -> some View {
+        HStack(spacing: 0) {
+            Text(months[monthIndex])
+                .frame(width: 80, height: 40, alignment: .leading)
+                .border(Color.gray)
+            ForEach(members) { member in
+                let fields = userFields[member.username] ?? []
+                let value = monthIndex < fields.count ? fields[monthIndex] : 0
+                Text(value > 0 ? "\(value)" : "-")
+                    .frame(width: 120, height: 40)
+                    .background(value > 0 ? Color.green.opacity(0.3) : Color.clear)
+                    .border(Color.gray)
+            }
+        }
+    }
+
+    private func loadData() {
+        members = DatabaseManager.shared.fetchMembers()
+        var dict: [String: [Int]] = [:]
+        for member in members {
+            if let values = DatabaseManager.shared.fetchUserFields(username: member.username) {
+                dict[member.username] = values
+            } else {
+                dict[member.username] = []
+            }
+        }
+        userFields = dict
+    }
+}
+
+#Preview {
+    PayStatusView()
+}


### PR DESCRIPTION
## Summary
- Move membership table into new `PayStatusView` with usernames across columns and months listed down the left.
- Replace `ManagementView` content with a button that opens `PayStatusView`.

## Testing
- ⚠️ `swift test` (no Package.swift found)
- ⚠️ `xcodebuild test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a8e55dbafc83319dd19a43ffa32ca9