### PR TITLE
Display instructions for manual verification code retrieval

### DIFF
--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -68,6 +68,10 @@ struct MemberVerificationView: View {
                 TextField("Enter verification code", text: $inputCode)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .padding()
+                Text("Ask In Cho for your code.\n(SMS Mobile Text verification is currently disabled because\nIn Cho does not want to pay for the Twilio Account)")
+                    .font(.footnote)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
                 HStack {
                     Button("Cancel") {
                         verifyingMember = nil


### PR DESCRIPTION
## Summary
- Inform users to ask In Cho for a verification code since SMS verification is disabled

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd3828c483319afa7ac20fdc5607