### PR TITLE
Hide guest members in reorder view

### DIFF
--- a/JokguApplication/PostHomeViews/ProUsers/ReorderMembersView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/ReorderMembersView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ReorderMembersView: View {
     @Environment(\.dismiss) var dismiss
     @State private var members: [Member] = []
+    @State private var guestMembers: [Member] = []
 
     var body: some View {
         List {
@@ -21,14 +22,24 @@ struct ReorderMembersView: View {
             }
         }
         .onAppear {
-            members = DatabaseManager.shared.fetchMembers()
+            let allMembers = DatabaseManager.shared.fetchMembers()
+            members = allMembers.filter { $0.guest != 0 }
+            guestMembers = allMembers.filter { $0.guest == 0 }
+            updateOrderIndices()
         }
     }
 
     private func move(from source: IndexSet, to destination: Int) {
         members.move(fromOffsets: source, toOffset: destination)
+        updateOrderIndices()
+    }
+
+    private func updateOrderIndices() {
         for (index, member) in members.enumerated() {
             _ = DatabaseManager.shared.updateOrder(id: member.id, order: index)
+        }
+        for (offset, member) in guestMembers.enumerated() {
+            _ = DatabaseManager.shared.updateOrder(id: member.id, order: members.count + offset)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Filter out members with `guest` value of 0 in `ReorderMembersView`
- Maintain hidden guest members at the end of order indices

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acee1344fc83319a3d7a44a859e3dc