### PR TITLE
Move member reordering into management membership

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -120,13 +120,6 @@ struct MemberView: View {
                     }
                     .pickerStyle(.menu)
                 }
-                if userPermit == 9 || userPermit == 2 {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        NavigationLink("Order") {
-                            ReorderMembersView()
-                        }
-                    }
-                }
             }
             .onAppear {
                 members = DatabaseManager.shared.fetchMembers()

--- a/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
@@ -35,6 +35,13 @@ struct PayStatusView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Back") { dismiss() }
                 }
+                if userPermit == 9 || userPermit == 2 {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        NavigationLink("Order") {
+                            ReorderMembersView()
+                        }
+                    }
+                }
             }
             .onAppear { loadData() }
         }


### PR DESCRIPTION
## Summary
- remove member ordering link from member view
- add member reordering link inside management's Membership page

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1d9326708331858c764d58660328