### PR TITLE
Ensure verification code input is uppercase alphanumeric

### DIFF
--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -67,6 +67,11 @@ struct MemberVerificationView: View {
             VStack(spacing: 16) {
                 TextField("Enter verification code", text: $inputCode)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+                    .onChange(of: inputCode) { _, newValue in
+                        inputCode = newValue.filter { $0.isLetter || $0.isNumber }.uppercased()
+                    }
                     .padding()
                 Text("Ask In Cho for your code.\n(SMS Mobile Text Verification is currently disabled because\nIn Cho does not want to pay for the Twilio Account)")
                     .font(.footnote)


### PR DESCRIPTION
## Summary
- Restrict verification code entry to uppercase letters and digits in member verification flow

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3dcbb6288331a8b4050dd9cca1c5