### PR TITLE
Remove FirebaseFirestoreSwift import to fix build error

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -1,6 +1,5 @@
 import Foundation
 import FirebaseFirestore
-import FirebaseFirestoreSwift
 import CryptoKit
 
 struct KeyCode: Identifiable {


### PR DESCRIPTION
## Summary
- drop unused FirebaseFirestoreSwift import from DatabaseManager

## Testing
- `swift build` (fails: Could not find Package.swift)
- `xcodebuild -version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae540b00f0833198ea99a33d2b9e44