### PR TITLE
refactor: use PersistentCacheSettings for Firestore

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -44,7 +44,7 @@ class DatabaseManager {
     private init() {
         let firestore = Firestore.firestore()
         let settings = firestore.settings
-        settings.isPersistenceEnabled = true
+        settings.cacheSettings = PersistentCacheSettings()
         firestore.settings = settings
         self.db = firestore
     }


### PR DESCRIPTION
## Summary
- replace deprecated Firestore `isPersistenceEnabled` with `PersistentCacheSettings`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae54a1ae88833184ae0772eabf8e52