### PR TITLE
Move daily today reset to backend

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -375,12 +375,6 @@ class DatabaseManager {
         }
     }
 
-    func resetTodayForAll() {
-        db.collection("member").getDocuments { snapshot, _ in
-            snapshot?.documents.forEach { $0.reference.updateData(["today": 0]) }
-        }
-    }
-
     // MARK: - Management
     func fetchManagementData() async throws -> [KeyCode] {
         try await withCheckedThrowingContinuation { continuation in

--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -119,7 +119,6 @@ struct HomeView: View {
         .onAppear {
             UNUserNotificationCenter.current().setBadgeCount(0) { _ in }
             loadManagement()
-            performDailyResetIfNeeded()
             checkTodayStatus()
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -135,18 +134,6 @@ struct HomeView: View {
             if let item = try? await DatabaseManager.shared.fetchManagementData().first {
                 await MainActor.run { management = item }
             }
-        }
-    }
-
-    private func performDailyResetIfNeeded() {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        let todayString = formatter.string(from: Date())
-        let defaults = UserDefaults.standard
-        let lastReset = defaults.string(forKey: "lastTodayReset")
-        if lastReset != todayString {
-            DatabaseManager.shared.resetTodayForAll()
-            defaults.set(todayString, forKey: "lastTodayReset")
         }
     }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,28 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+async function resetToday(db) {
+  const snapshot = await db.collection('member').get();
+  const batch = db.batch();
+  snapshot.forEach(doc => {
+    batch.update(doc.ref, { today: 0 });
+  });
+  await batch.commit();
+}
+
+exports.scheduledDailyReset = functions.pubsub
+  .schedule('0 0 * * *')
+  .timeZone('Asia/Seoul')
+  .onRun(async () => {
+    await resetToday(admin.firestore());
+    console.log('Today fields reset');
+  });
+
+exports.adminResetToday = functions.https.onCall(async (data, context) => {
+  if (!context.auth || context.auth.token.admin !== true) {
+    throw new functions.https.HttpsError('permission-denied', 'Admin privileges required.');
+  }
+  await resetToday(admin.firestore());
+  return { status: 'ok' };
+});

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "jokgu-functions",
+  "engines": {
+    "node": "18"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.0.0",
+    "firebase-functions": "^4.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Remove client-side daily reset logic in HomeView and DatabaseManager
- Add Firebase Cloud Functions to reset `today` field daily and allow admin manual resets

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c16b4208331b307bf213dfcd8ba