### PR TITLE
Cache management data and inject via observable object

### DIFF
--- a/JokguApplication/Core/ContentView.swift
+++ b/JokguApplication/Core/ContentView.swift
@@ -16,4 +16,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environmentObject(DatabaseManager.shared)
 }


### PR DESCRIPTION
## Summary
- Cache the Firestore management document in `DatabaseManager` with a real-time listener.
- Expose cached management data via an `ObservableObject` and inject into app, home, and login views.
- Update views to consume the shared cache instead of repeatedly fetching.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5d19e99c8331a33253da2cd4da7e