### PR TITLE
Initialize Firebase before Firestore usage

### DIFF
--- a/JokguApplication/JokguApplicationApp.swift
+++ b/JokguApplication/JokguApplicationApp.swift
@@ -6,26 +6,17 @@
 //
 
 import SwiftUI
-import UIKit
 import UserNotifications
 import FirebaseCore
 
-class AppDelegate: NSObject, UIApplicationDelegate { //UIResponder
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    FirebaseApp.configure()
-
-    return true
-  }
-}
-
 @main
 struct JokguApplicationApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @Environment(\.scenePhase) private var scenePhase
-    @StateObject private var databaseManager = DatabaseManager.shared
+    @StateObject private var databaseManager: DatabaseManager
 
     init() {
+        FirebaseApp.configure()
+        _databaseManager = StateObject(wrappedValue: DatabaseManager.shared)
         UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
         updateAppBadge()
     }


### PR DESCRIPTION
## Summary
- Configure Firebase at app startup
- Lazily initialize DatabaseManager after Firebase setup

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae667f81348331b0d81721ee23854f