### PR TITLE
Add AppDelegate and fix StateObject warning

### DIFF
--- a/JokguApplication/AppDelegate.swift
+++ b/JokguApplication/AppDelegate.swift
@@ -1,0 +1,15 @@
+import UIKit
+import FirebaseCore
+import FirebaseMessaging
+import UserNotifications
+
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        FirebaseApp.configure()
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
+        application.registerForRemoteNotifications()
+        return true
+    }
+}

--- a/JokguApplication/JokguApplicationApp.swift
+++ b/JokguApplication/JokguApplicationApp.swift
@@ -7,24 +7,20 @@
 
 import SwiftUI
 import UserNotifications
-import FirebaseCore
 
 @main
 struct JokguApplicationApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @Environment(\.scenePhase) private var scenePhase
-    @StateObject private var databaseManager: DatabaseManager
-
-    init() {
-        FirebaseApp.configure()
-        _databaseManager = StateObject(wrappedValue: DatabaseManager.shared)
-        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
-        updateAppBadge()
-    }
+    @StateObject private var databaseManager = DatabaseManager.shared
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(databaseManager)
+                .onAppear {
+                    updateAppBadge()
+                }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {


### PR DESCRIPTION
## Summary
- Introduce `AppDelegate` to manage Firebase configuration and notification authorization
- Use `UIApplicationDelegateAdaptor` in `JokguApplicationApp` and defer badge updates to avoid `StateObject` warning

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6894d658833185fdb82beeaa8b4e