### PR TITLE
Fix database manager StateObject usage

### DIFF
--- a/JokguApplication/JokguApplicationApp.swift
+++ b/JokguApplication/JokguApplicationApp.swift
@@ -21,14 +21,14 @@ struct JokguApplicationApp: App {
                 .onAppear {
                     updateAppBadge()
                 }
+                .onChange(of: databaseManager.management?.id) { _, _ in
+                    updateAppBadge()
+                }
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
                 updateAppBadge()
             }
-        }
-        .onChange(of: databaseManager.management?.id) { _, _ in
-            updateAppBadge()
         }
     }
 


### PR DESCRIPTION
## Summary
- Attach database manager's onChange handler inside `WindowGroup` to ensure the `StateObject` is installed on a view

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae69aa5cb88331a064bbd7ade36bad