### PR TITLE
Seed default management keycode on first run

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -56,7 +56,17 @@ final class DatabaseManager: ObservableObject {
     private func listenToManagement() {
         managementListener?.remove()
         managementListener = db.collection("management").addSnapshotListener { snapshot, _ in
-            guard let doc = snapshot?.documents.first,
+            guard let snapshot = snapshot else { return }
+
+            if snapshot.documents.isEmpty {
+                self.db.collection("management").document("default").setData([
+                    "id": 1,
+                    "keycode": "1234"
+                ])
+                return
+            }
+
+            guard let doc = snapshot.documents.first,
                   let item = self.keyCodeFromDoc(doc) else { return }
             DispatchQueue.main.async {
                 self.management = item


### PR DESCRIPTION
## Summary
- create default management document with keycode 1234 when Firestore lacks management data

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6ad6c09c8331a2d7d090af12fcc0