### PR TITLE
Allow multiline notifications on management screen

### DIFF
--- a/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/ManagementView.swift
@@ -61,8 +61,12 @@ struct ManagementView: View {
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Notification").font(.caption)
-                        TextField("Notification", text: $keyCode.notification)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                        TextEditor(text: $keyCode.notification)
+                            .frame(minHeight: 80)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 5)
+                                    .stroke(Color.gray.opacity(0.5))
+                            )
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Game day(s)").font(.caption)


### PR DESCRIPTION
## Summary
- allow multiline notification entry

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae707d87f48331b41e712a2e28bd92