### PR TITLE
Sanitize phone numbers before Firebase verification

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -196,7 +196,8 @@ struct LoginView: View {
                         .padding(.horizontal)
 
                     Button("Send Code") {
-                        let phone = recoveryPhoneNumber.hasPrefix("+") ? recoveryPhoneNumber : "+1" + recoveryPhoneNumber
+                        let digits = recoveryPhoneNumber.filter { $0.isNumber }
+                        let phone = digits.hasPrefix("1") ? "+" + digits : "+1" + digits
                         isSendingRecoveryCode = true
                         PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { id, error in
                             DispatchQueue.main.async {

--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -36,7 +36,8 @@ struct MemberVerificationView: View {
                     Button("Verify") {
                         if let member = selectedMember {
                             isSendingCode = true
-                            let phone = member.phoneNumber.hasPrefix("+") ? member.phoneNumber : "+1" + member.phoneNumber
+                            let digits = member.phoneNumber.filter { $0.isNumber }
+                            let phone = digits.hasPrefix("1") ? "+" + digits : "+1" + digits
                             PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { id, error in
                                 DispatchQueue.main.async {
                                     isSendingCode = false


### PR DESCRIPTION
## Summary
- Format phone numbers to digits-only and add country code before calling Firebase phone verification in login recovery and member verification flows.

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae76acfbe48331bf3fad3104eaf1df