### PR TITLE
Fix payment view freeze by fetching user fields asynchronously

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
@@ -110,14 +110,14 @@ struct PaymentView: View {
     }
 
     private func loadData() {
-        if let fetched = DatabaseManager.shared.fetchUserFields(username: username) {
-            var filled = Array(repeating: 0, count: 12)
-            for i in 0..<min(fetched.count, 12) {
-                filled[i] = fetched[i]
-            }
-            fields = filled
-        }
         Task {
+            if let fetched = await DatabaseManager.shared.fetchUserFields(username: username) {
+                var filled = Array(repeating: 0, count: 12)
+                for i in 0..<min(fetched.count, 12) {
+                    filled[i] = fetched[i]
+                }
+                await MainActor.run { fields = filled }
+            }
             if let management = try? await DatabaseManager.shared.fetchManagementData().first {
                 await MainActor.run {
                     fee = management.fee

--- a/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
@@ -115,7 +115,7 @@ struct PayStatusView: View {
                 let filtered = fetched.filter { $0.guest == 1 }
                 var dict: [String: [String]] = [:]
                 for member in filtered {
-                    if let values = DatabaseManager.shared.fetchUserFields(username: member.username) {
+                    if let values = await DatabaseManager.shared.fetchUserFields(username: member.username) {
                         var strings = values.map { String($0) }
                         if strings.count < months.count {
                             strings += Array(repeating: "", count: months.count - strings.count)


### PR DESCRIPTION
## Summary
- Prevent UI freeze by fetching user fields asynchronously instead of blocking with semaphores
- Load payment data in a background task on PaymentView
- Update PayStatusView to use async user field retrieval

## Testing
- `npm test` (fails: Missing script: "test")
- `swift build` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68ae84bcdd6c8331ae210086ea21c937