### PR TITLE
Fix payment-related view freezes with async user field calls

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -483,35 +483,31 @@ final class DatabaseManager: ObservableObject {
     }
 
     // MARK: - User Fields
-    func saveUserFields(username: String, fields: [Int]) -> Bool {
-        let sem = DispatchSemaphore(value: 0)
-        var data: [String: Any] = ["username": username.uppercased()]
-        for (index, value) in fields.enumerated() {
-            data["field\(index + 1)"] = value
+    func saveUserFields(username: String, fields: [Int]) async -> Bool {
+        await withCheckedContinuation { continuation in
+            var data: [String: Any] = ["username": username.uppercased()]
+            for (index, value) in fields.enumerated() {
+                data["field\(index + 1)"] = value
+            }
+            db.collection("user_fields").document(username.uppercased()).setData(data) { error in
+                continuation.resume(returning: error == nil)
+            }
         }
-        var success = false
-        db.collection("user_fields").document(username.uppercased()).setData(data) { error in
-            success = error == nil
-            sem.signal()
-        }
-        sem.wait()
-        return success
     }
 
-    func fetchUserFields(username: String) -> [Int]? {
-        let sem = DispatchSemaphore(value: 0)
-        var values: [Int]? = nil
-        db.collection("user_fields").document(username.uppercased()).getDocument { doc, _ in
-            if let doc = doc, doc.exists {
+    func fetchUserFields(username: String) async -> [Int]? {
+        await withCheckedContinuation { continuation in
+            db.collection("user_fields").document(username.uppercased()).getDocument { doc, _ in
+                guard let doc = doc, doc.exists else {
+                    continuation.resume(returning: nil)
+                    return
+                }
                 var arr: [Int] = []
                 for i in 1...12 {
                     arr.append(doc.data()? ["field\(i)"] as? Int ?? 0)
                 }
-                values = arr
+                continuation.resume(returning: arr)
             }
-            sem.signal()
         }
-        sem.wait()
-        return values
     }
 }

--- a/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
@@ -110,14 +110,14 @@ struct PaymentView: View {
     }
 
     private func loadData() {
-        if let fetched = DatabaseManager.shared.fetchUserFields(username: username) {
-            var filled = Array(repeating: 0, count: 12)
-            for i in 0..<min(fetched.count, 12) {
-                filled[i] = fetched[i]
-            }
-            fields = filled
-        }
         Task {
+            if let fetched = await DatabaseManager.shared.fetchUserFields(username: username) {
+                var filled = Array(repeating: 0, count: 12)
+                for i in 0..<min(fetched.count, 12) {
+                    filled[i] = fetched[i]
+                }
+                await MainActor.run { fields = filled }
+            }
             if let management = try? await DatabaseManager.shared.fetchManagementData().first {
                 await MainActor.run {
                     fee = management.fee

--- a/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
@@ -80,7 +80,9 @@ struct PayStatusView: View {
                         fields[monthIndex] = newValue
                         userFields[member.username] = fields
                         let intFields = fields.map { Int($0) ?? 0 }
-                        _ = DatabaseManager.shared.saveUserFields(username: member.username, fields: intFields)
+                        Task {
+                            _ = await DatabaseManager.shared.saveUserFields(username: member.username, fields: intFields)
+                        }
                     }
                 )
                 TextField("-", text: binding)
@@ -115,7 +117,7 @@ struct PayStatusView: View {
                 let filtered = fetched.filter { $0.guest == 1 }
                 var dict: [String: [String]] = [:]
                 for member in filtered {
-                    if let values = DatabaseManager.shared.fetchUserFields(username: member.username) {
+                    if let values = await DatabaseManager.shared.fetchUserFields(username: member.username) {
                         var strings = values.map { String($0) }
                         if strings.count < months.count {
                             strings += Array(repeating: "", count: months.count - strings.count)


### PR DESCRIPTION
## Summary
- Prevent UI freezes by fetching user fields asynchronously instead of blocking with semaphores
- Load payment data in a background task on PaymentView
- Save edited membership fields asynchronously in PayStatusView

## Testing
- `npm test` (fails: Could not read package.json)
- `swift build` (fails: Could not find Package.swift)


------
https://chatgpt.com/codex/tasks/task_e_68ae84bcdd6c8331ae210086ea21c937