### PR TITLE
Handle password mismatch and link starred addresses

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -125,7 +125,11 @@ struct ProfileView: View {
                                     }
                                 } catch {
                                     await MainActor.run {
-                                        showMessage("Current password incorrect", color: .red)
+                                        if (error as NSError).domain == "InvalidPassword" {
+                                            showMessage("Current password incorrect", color: .red)
+                                        } else {
+                                            showMessage("Unable to update password", color: .red)
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- Show clearer error when current password is incorrect during profile password update
- Turn **address** blocks from management notifications into tappable map links on home view

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d9609b083318bd6ef99d64c341a