### PR TITLE
Handle notification authorization states

### DIFF
--- a/JokguApplication/AppDelegate.swift
+++ b/JokguApplication/AppDelegate.swift
@@ -8,8 +8,38 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
         UNUserNotificationCenter.current().delegate = self
-        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
+        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                switch settings.authorizationStatus {
+                case .denied:
+                    self.presentNotificationsDisabledAlert()
+                case .provisional:
+                    break
+                default:
+                    break
+                }
+            }
+        }
         application.registerForRemoteNotifications()
         return true
+    }
+
+    private func presentNotificationsDisabledAlert() {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "Notifications Disabled",
+                                          message: "Enable notifications in Settings.",
+                                          preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: "Settings", style: .default) { _ in
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
+            })
+
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let root = windowScene.windows.first?.rootViewController {
+                root.present(alert, animated: true, completion: nil)
+            }
+        }
     }
 }

--- a/JokguApplication/JokguApplicationApp.swift
+++ b/JokguApplication/JokguApplicationApp.swift
@@ -38,7 +38,11 @@ struct JokguApplicationApp: App {
         let today = formatter.string(from: Date())
         let badgeCount = (databaseManager.management?.playwhen.contains(today) == true) ? 1 : 0
         UNUserNotificationCenter.current().setBadgeCount(badgeCount) { _ in }
-        scheduleNoonAlertIfNeeded(badgeCount: badgeCount)
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            if settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional {
+                scheduleNoonAlertIfNeeded(badgeCount: badgeCount)
+            }
+        }
     }
 
     private func scheduleNoonAlertIfNeeded(badgeCount: Int) {


### PR DESCRIPTION
## Summary
- Inspect notification authorization after requesting permission and prompt users to enable notifications in Settings when disabled.
- Only schedule noon reminders when notifications are authorized or provisional.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae90c2242c833188939d15f57c5670