### PR TITLE
Prevent strong password overlay on current password field

### DIFF
--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -95,7 +95,12 @@ struct ProfileView: View {
                     Divider().padding(.vertical)
 
                     SecureField("Current Password", text: $currentPassword)
-                        .textContentType(.password)
+                        // Use a content type that prevents iOS from offering
+                        // strong password suggestions when editing the current
+                        // password field. Without this, the system can overlay
+                        // a "strong password" suggestion view that blocks user
+                        // input.
+                        .textContentType(.oneTimeCode)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
                         .textFieldStyle(RoundedBorderTextFieldStyle())


### PR DESCRIPTION
## Summary
- disable iOS strong password suggestions for current password entry in ProfileView by using `.oneTimeCode`
- document why the content type is set this way

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae936f8b008331983bcb9ff593e183