### PR TITLE
Store profile pictures in Firebase Storage

### DIFF
--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -31,7 +31,6 @@ struct RegisterView: View {
             _dob = State(initialValue: nil)
         }
         _username = State(initialValue: "")
-        _pictureData = State(initialValue: member?.picture)
     }
 
     var body: some View {

--- a/JokguApplication/PostHomeViews/AllUsers/LineupView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/LineupView.swift
@@ -18,13 +18,19 @@ struct LineupView: View {
                     LazyVGrid(columns: columns, spacing: 20) {
                         ForEach(members) { member in
                             VStack {
-                                if let data = member.picture,
-                                   let uiImage = UIImage(data: data) {
-                                    Image(uiImage: uiImage)
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(width: 80, height: 80)
-                                        .clipShape(Circle())
+                                if let urlString = member.pictureURL,
+                                   let url = URL(string: urlString) {
+                                    AsyncImage(url: url) { phase in
+                                        if let image = phase.image {
+                                            image.resizable().scaledToFill()
+                                        } else {
+                                            Image("default-profile")
+                                                .resizable()
+                                                .scaledToFill()
+                                        }
+                                    }
+                                    .frame(width: 80, height: 80)
+                                    .clipShape(Circle())
                                 } else {
                                     Image("default-profile")
                                         .resizable()

--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -58,13 +58,19 @@ struct MemberView: View {
                 ForEach(members.indices, id: \.self) { index in
                     let member = members[index]
                     HStack(alignment: .top) {
-                        if let data = member.picture,
-                           let uiImage = UIImage(data: data) {
-                            Image(uiImage: uiImage)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 60, height: 60)
-                                .clipShape(Circle())
+                        if let urlString = member.pictureURL,
+                           let url = URL(string: urlString) {
+                            AsyncImage(url: url) { phase in
+                                if let image = phase.image {
+                                    image.resizable().scaledToFill()
+                                } else {
+                                    Image("default-profile")
+                                        .resizable()
+                                        .scaledToFill()
+                                }
+                            }
+                            .frame(width: 60, height: 60)
+                            .clipShape(Circle())
                         } else {
                             Image("default-profile")
                                 .resizable()

--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -15,6 +15,7 @@ struct ProfileView: View {
     @State private var messageColor: Color = .red
     @State private var selectedPhoto: PhotosPickerItem? = nil
     @State private var pictureData: Data? = nil
+    @State private var pictureURL: String? = nil
 
     var body: some View {
         NavigationView {
@@ -28,6 +29,19 @@ struct ProfileView: View {
                                 .scaledToFill()
                                 .frame(width: 100, height: 100)
                                 .clipShape(Circle())
+                        } else if let pictureURL,
+                                  let url = URL(string: pictureURL) {
+                            AsyncImage(url: url) { phase in
+                                if let image = phase.image {
+                                    image.resizable().scaledToFill()
+                                } else {
+                                    Image("default-profile")
+                                        .resizable()
+                                        .scaledToFill()
+                                }
+                            }
+                            .frame(width: 100, height: 100)
+                            .clipShape(Circle())
                         } else {
                             Image("default-profile")
                                 .resizable()
@@ -39,7 +53,8 @@ struct ProfileView: View {
                     .onChange(of: selectedPhoto) { _, newItem in
                         Task {
                             if let data = try? await newItem?.loadTransferable(type: Data.self) {
-                                pictureData = data
+                            pictureData = data
+                            pictureURL = nil
                             }
                         }
                     }
@@ -172,7 +187,7 @@ struct ProfileView: View {
                             lastName = member.lastName
                             phoneNumber = member.phoneNumber
                             dob = dateFormatter.date(from: member.dob)
-                            pictureData = member.picture
+                            pictureURL = member.pictureURL
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Upload profile pictures to Firebase Storage and persist download URLs in Firestore
- Load profile images via `AsyncImage` throughout the app

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ae950fc13c8331b3855e733bf202cb