### PR TITLE
Limit today reset to positive values

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9,7 +9,7 @@ admin.initializeApp();
 setGlobalOptions({ region: 'us-central1', maxInstances: 10 });
 
 async function resetToday(db) {
-  const snap = await db.collection('member').where('today', '!=', 0).get();
+  const snap = await db.collection('member').where('today', '>', 0).get();
   if (snap.empty) return;
 
   const docs = snap.docs;


### PR DESCRIPTION
## Summary
- Use `where('today', '>', 0)` so only members with positive `today` values are processed

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af373c3bbc83318a63e38732998a5d