### PR TITLE
feat: tighten Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,18 +2,21 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Management documents: only admins may write
+    match /management/{docId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
 
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
+    // Member documents: users may write their own document
+    match /member/{docId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == docId;
+    }
+
+    // All other documents require authentication
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2025, 9, 25);
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- require authentication for all Firestore access
- restrict `/management` writes to admin users
- limit `/member/{docId}` writes to the owner's UID

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm --prefix functions run lint`
- `firebase deploy --only firestore:rules` *(fails: Failed to authenticate)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b040ff88331bf0a2cb8b1613d79