### PR TITLE
Add profile picture storage rules

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -5,6 +5,11 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+    match /profile_pictures/{userId}.jpg {
+      allow read: if request.auth != null;
+      allow write: if request.auth.uid == userId;
+    }
+
     match /{allPaths=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
## Summary
- permit authenticated read and owner write for profile pictures in Firebase Storage
- explicitly deny access to all other storage paths

## Testing
- `npm --prefix functions run lint`
- `firebase deploy --only storage` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b15f1d88331809ef838aa1aafe4