### PR TITLE
Forward remote notifications to FirebaseAuth

### DIFF
--- a/JokguApplication/AppDelegate.swift
+++ b/JokguApplication/AppDelegate.swift
@@ -34,6 +34,17 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         Messaging.messaging().apnsToken = deviceToken
     }
 
+    func application(_ application: UIApplication,
+                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        if Auth.auth().canHandleNotification(userInfo) {
+            completionHandler(.noData)
+            return
+        }
+
+        completionHandler(.noData)
+    }
+
     private func presentNotificationsDisabledAlert() {
         DispatchQueue.main.async {
             let alert = UIAlertController(title: "Notifications Disabled",


### PR DESCRIPTION
## Summary
- Forward incoming remote notifications from the app delegate to `FirebaseAuth.canHandleNotification`
- Ensure completion handler is invoked when the notification is handled

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcc1a896483319c7af37cf6d17b81