### PR TITLE
Ensure phone-based password recovery proceeds correctly

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -206,6 +206,8 @@ struct LoginView: View {
                             recoveryError = "Phone number must be 10 or 11 digits"
                             return
                         }
+                        // Store standardized phone number for later lookup
+                        recoveryPhoneNumber = phone
                         isSendingRecoveryCode = true
                         PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { id, error in
                             DispatchQueue.main.async {
@@ -239,6 +241,12 @@ struct LoginView: View {
                                                 recoveryCodeInput = ""
                                                 recoveryVerificationID = nil
                                                 recoveryMember = member
+                                                try? Auth.auth().signOut()
+                                            }
+                                        } else {
+                                            await MainActor.run {
+                                                recoveryError = "No account found for this phone number"
+                                                recoveryVerificationID = nil
                                                 try? Auth.auth().signOut()
                                             }
                                         }


### PR DESCRIPTION
## Summary
- Normalize recovery phone numbers before sending verification codes
- Report a clear error when no account matches the verified phone number

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afdf4e531c83319fe59f58e94f8a63