### PR TITLE
Remove phone number fields and use phone auth for recovery

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -22,7 +22,6 @@ struct Member: Identifiable {
     var username: String
     var firstName: String
     var lastName: String
-    var phoneNumber: String
     var dob: String
     var pictureURL: String?
     var attendance: Int
@@ -31,7 +30,6 @@ struct Member: Identifiable {
     var today: Int
     var syncd: Int
     var orderIndex: Int
-    var recovery: Int
 }
 
 struct UserFields {
@@ -96,7 +94,6 @@ final class DatabaseManager: ObservableObject {
         let username = data["username"] as? String ?? ""
         let firstName = data["firstname"] as? String ?? ""
         let lastName = data["lastname"] as? String ?? ""
-        let phoneNumber = data["phonenumber"] as? String ?? ""
         let dob = data["dob"] as? String ?? ""
         let pictureURL = data["picture"] as? String
         let attendance = data["attendance"] as? Int ?? 0
@@ -105,10 +102,9 @@ final class DatabaseManager: ObservableObject {
         let today = data["today"] as? Int ?? 0
         let syncd = data["syncd"] as? Int ?? 0
         let orderIndex = data["orderIndex"] as? Int ?? 0
-        let recovery = data["recovery"] as? Int ?? 0
         memberRefCache[id] = doc.reference
         memberUsernameRefCache[username.uppercased()] = doc.reference
-        return Member(id: id, username: username, firstName: firstName, lastName: lastName, phoneNumber: phoneNumber, dob: dob, pictureURL: pictureURL, attendance: attendance, permit: permit, guest: guest, today: today, syncd: syncd, orderIndex: orderIndex, recovery: recovery)
+        return Member(id: id, username: username, firstName: firstName, lastName: lastName, dob: dob, pictureURL: pictureURL, attendance: attendance, permit: permit, guest: guest, today: today, syncd: syncd, orderIndex: orderIndex)
     }
 
     private func keyCodeFromDoc(_ doc: DocumentSnapshot) -> KeyCode? {
@@ -189,7 +185,7 @@ final class DatabaseManager: ObservableObject {
         }
     }
 
-    func insertUser(username: String, password: String, firstName: String, lastName: String, phoneNumber: String, dob: String, picture: Data?) async throws {
+    func insertUser(username: String, password: String, firstName: String, lastName: String, dob: String, picture: Data?) async throws {
         let upperUsername = username.uppercased()
         guard try await !userExists(upperUsername) else { throw NSError(domain: "UserExists", code: 1) }
 
@@ -245,15 +241,13 @@ final class DatabaseManager: ObservableObject {
             "salt": salt,
             "firstname": firstName,
             "lastname": lastName,
-            "phonenumber": phoneNumber,
             "dob": dob,
             "attendance": 0,
             "permit": 0,
             "guest": 0,
             "today": 0,
             "syncd": 1,
-            "orderIndex": newId,
-            "recovery": Int.random(in: 100000...999999)
+            "orderIndex": newId
         ]
         if let picture = picture {
             let storageRef = Storage.storage().reference().child("profile_pictures/\(upperUsername).jpg")
@@ -377,34 +371,6 @@ final class DatabaseManager: ObservableObject {
         }
     }
 
-    func fetchMemberByRecovery(code: Int) async throws -> Member? {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Member?, Error>) in
-            db.collection("member").whereField("recovery", isEqualTo: code).limit(to: 1).getDocuments { snapshot, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let doc = snapshot?.documents.first {
-                    continuation.resume(returning: self.memberFromDoc(doc))
-                } else {
-                    continuation.resume(returning: nil)
-                }
-            }
-        }
-    }
-
-    func fetchMemberByPhoneNumber(phoneNumber: String) async throws -> Member? {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Member?, Error>) in
-            db.collection("member").whereField("phonenumber", isEqualTo: phoneNumber).limit(to: 1).getDocuments { snapshot, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                } else if let doc = snapshot?.documents.first {
-                    continuation.resume(returning: self.memberFromDoc(doc))
-                } else {
-                    continuation.resume(returning: nil)
-                }
-            }
-        }
-    }
-
     func fetchUnsyncedMembers() async throws -> [Member] {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[Member], Error>) in
             db.collection("member").whereField("syncd", isEqualTo: 0).getDocuments { snapshot, error in
@@ -480,11 +446,10 @@ final class DatabaseManager: ObservableObject {
         try await updateMember(id: id, fields: ["username": username.uppercased(), "passwordHash": hashPassword(password, salt: salt), "salt": salt])
     }
 
-    func updateUser(username: String, firstName: String, lastName: String, phoneNumber: String, dob: String, picture: Data?) async throws {
+    func updateUser(username: String, firstName: String, lastName: String, dob: String, picture: Data?) async throws {
         var fields: [String: Any] = [
             "firstname": firstName,
             "lastname": lastName,
-            "phonenumber": phoneNumber,
             "dob": dob
         ]
         if let picture = picture {

--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -11,6 +11,7 @@ struct MemberVerificationView: View {
     @State private var verificationID: String? = nil
     @State private var isSendingCode = false
     @State private var errorMessage: String? = nil
+    @State private var phoneNumber: String = ""
 
     var body: some View {
         NavigationView {
@@ -27,6 +28,11 @@ struct MemberVerificationView: View {
                         selectedMember = member
                     }
                 }
+                TextField("Phone Number", text: $phoneNumber)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .keyboardType(.phonePad)
+                    .padding()
+
                 HStack {
                     Button("New") {
                         selectedMember = nil
@@ -35,9 +41,17 @@ struct MemberVerificationView: View {
                     Spacer()
                     Button("Verify") {
                         if let member = selectedMember {
+                            let digits = phoneNumber.filter { $0.isNumber }
+                            let phone: String
+                            if digits.count == 10 {
+                                phone = "+1" + digits
+                            } else if digits.count == 11 {
+                                phone = "+" + digits
+                            } else {
+                                errorMessage = "Phone number must be 10 or 11 digits"
+                                return
+                            }
                             isSendingCode = true
-                            let digits = member.phoneNumber.filter { $0.isNumber }
-                            let phone = digits.hasPrefix("1") ? "+" + digits : "+1" + digits
                             PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { id, error in
                                 DispatchQueue.main.async {
                                     isSendingCode = false
@@ -51,7 +65,7 @@ struct MemberVerificationView: View {
                             }
                         }
                     }
-                    .disabled(selectedMember == nil || isSendingCode)
+                    .disabled(selectedMember == nil || phoneNumber.isEmpty || isSendingCode)
                 }
                 .padding()
             }

--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -27,7 +27,7 @@ struct RegisterView: View {
         self.onComplete = onComplete
         _firstName = State(initialValue: member?.firstName ?? "")
         _lastName = State(initialValue: member?.lastName ?? "")
-        _phoneNumber = State(initialValue: member?.phoneNumber ?? "")
+        _phoneNumber = State(initialValue: "")
         if let dobString = member?.dob {
             let formatter = DateFormatter()
             formatter.dateFormat = "MM/dd/yyyy"
@@ -252,7 +252,6 @@ struct RegisterView: View {
         let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
         let trimmedFirst = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedLast = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let dob = dob else { return }
         do {
             if try await DatabaseManager.shared.userExists(trimmedUser) {
@@ -263,7 +262,6 @@ struct RegisterView: View {
                     password: password,
                     firstName: trimmedFirst,
                     lastName: trimmedLast,
-                    phoneNumber: trimmedPhone,
                     dob: dateFormatter.string(from: dob),
                     picture: pictureData ?? UIImage(named: "default-profile")?.pngData()
                 )

--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -97,11 +97,7 @@ struct MemberView: View {
                         VStack(alignment: .leading) {
                             Text("\(member.lastName) \(member.firstName)")
                             Text("DOB: \(member.dob)")
-                            Text("Phone: \(member.phoneNumber)")
                             Text("Attendance: \(member.attendance)")
-                            if userPermit == 2 {
-                                Text("Recovery: \(member.recovery)")
-                            }
                             if userPermit == 9 || userPermit == 2 {
                                 Toggle("Guest", isOn: Binding(
                                     get: { members[index].guest == 1 },

--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -6,7 +6,6 @@ struct ProfileView: View {
     let username: String
     @State private var firstName: String = ""
     @State private var lastName: String = ""
-    @State private var phoneNumber: String = ""
     @State private var dob: Date? = nil
     @State private var currentPassword: String = ""
     @State private var newPassword: String = ""
@@ -83,14 +82,6 @@ struct ProfileView: View {
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .padding(.horizontal)
 
-                    TextField("Phone Number", text: $phoneNumber)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .keyboardType(.phonePad)
-                        .padding(.horizontal)
-                        .onChange(of: phoneNumber) { _, newValue in
-                            phoneNumber = formatPhoneNumber(newValue)
-                        }
-
                     DatePicker("Date of Birth", selection: Binding(
                         get: { dob ?? Date() },
                         set: { dob = $0 }
@@ -102,14 +93,12 @@ struct ProfileView: View {
                     Button("Save Info") {
                         let trimmedFirst = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
                         let trimmedLast = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                        if trimmedFirst.isEmpty || trimmedLast.isEmpty || trimmedPhone.isEmpty || dob == nil {
+                        if trimmedFirst.isEmpty || trimmedLast.isEmpty || dob == nil {
                             showMessage("All fields are required", color: .red)
                         } else {
                             Task {
                                 do {
-                                    try await DatabaseManager.shared.updateUser(username: username, firstName: trimmedFirst, lastName: trimmedLast, phoneNumber: trimmedPhone, dob: dateFormatter.string(from: dob!), picture: pictureData)
+                                    try await DatabaseManager.shared.updateUser(username: username, firstName: trimmedFirst, lastName: trimmedLast, dob: dateFormatter.string(from: dob!), picture: pictureData)
                                     await MainActor.run {
                                         showMessage("Information updated", color: .green)
                                     }
@@ -201,7 +190,6 @@ struct ProfileView: View {
                         await MainActor.run {
                             firstName = member.firstName
                             lastName = member.lastName
-                            phoneNumber = member.phoneNumber
                             dob = dateFormatter.date(from: member.dob)
                             pictureURL = member.pictureURL
                         }
@@ -225,23 +213,6 @@ struct ProfileView: View {
         return formatter
     }
 
-    private func formatPhoneNumber(_ number: String) -> String {
-        let digits = number.filter { $0.isNumber }
-        let limited = String(digits.prefix(10))
-        let area = limited.prefix(3)
-        let middle = limited.dropFirst(3).prefix(3)
-        let last = limited.dropFirst(6)
-        var result = ""
-        if !area.isEmpty {
-            result += "(" + area
-            if area.count == 3 { result += ")" }
-        }
-        result += middle
-        if !last.isEmpty {
-            result += "-" + last
-        }
-        return result
-    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- drop `phonenumber` and `recovery` fields from member records
- rely on Firebase Phone Auth for password recovery and verification
- clean up profile and member views to remove phone number details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afea73fb2883319221bd1d95f5a0e7