### PR TITLE
Support anonymous auth for initial Firestore access

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import FirebaseFirestore
 import FirebaseStorage
+import FirebaseAuth
 import CryptoKit
 import Combine
 
@@ -52,7 +53,15 @@ final class DatabaseManager: ObservableObject {
         settings.cacheSettings = PersistentCacheSettings()
         firestore.settings = settings
         self.db = firestore
-        listenToManagement()
+
+        Auth.auth().addStateDidChangeListener { [weak self] auth, user in
+            guard let self = self else { return }
+            if user == nil {
+                auth.signInAnonymously { _, _ in }
+            } else {
+                self.listenToManagement()
+            }
+        }
     }
 
     private func listenToManagement() {


### PR DESCRIPTION
## Summary
- Sign in to Firebase anonymously when no user is present
- Listen for auth state changes to refresh management data

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68affd0f12f48331a262d6a8d0889041