### PR TITLE
Use default keycode without creating anonymous user

### DIFF
--- a/JokguApplication/AppDelegate.swift
+++ b/JokguApplication/AppDelegate.swift
@@ -8,9 +8,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
-        if Auth.auth().currentUser == nil {
-            Auth.auth().signInAnonymously(completion: nil)
-        }
+        // Anonymous authentication is disabled on initial run.
+        // Previously the app would create an anonymous user if none existed.
+        // Now, if no user is signed in, the app continues without creating one.
         UNUserNotificationCenter.current().delegate = self
         UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in
             UNUserNotificationCenter.current().getNotificationSettings { settings in

--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -62,10 +62,21 @@ final class DatabaseManager: ObservableObject {
             guard let snapshot = snapshot else { return }
 
             if snapshot.documents.isEmpty {
-                self.db.collection("management").document("default").setData([
-                    "id": 1,
-                    "keycode": "1234"
-                ])
+                let defaultKeyCode = KeyCode(
+                    id: 1,
+                    code: "1234",
+                    address: "",
+                    welcome: "",
+                    youtube: nil,
+                    kakao: nil,
+                    notification: "",
+                    playwhen: [],
+                    fee: 0,
+                    venmo: ""
+                )
+                DispatchQueue.main.async {
+                    self.management = defaultKeyCode
+                }
                 return
             }
 
@@ -575,10 +586,27 @@ final class DatabaseManager: ObservableObject {
                     continuation.resume(throwing: error)
                 } else {
                     let items = snapshot?.documents.compactMap { self.keyCodeFromDoc($0) } ?? []
-                    if let first = items.first {
-                        DispatchQueue.main.async { self.management = first }
+                    if items.isEmpty {
+                        let defaultKeyCode = KeyCode(
+                            id: 1,
+                            code: "1234",
+                            address: "",
+                            welcome: "",
+                            youtube: nil,
+                            kakao: nil,
+                            notification: "",
+                            playwhen: [],
+                            fee: 0,
+                            venmo: ""
+                        )
+                        DispatchQueue.main.async { self.management = defaultKeyCode }
+                        continuation.resume(returning: [defaultKeyCode])
+                    } else {
+                        if let first = items.first {
+                            DispatchQueue.main.async { self.management = first }
+                        }
+                        continuation.resume(returning: items)
                     }
-                    continuation.resume(returning: items)
                 }
             }
         }
@@ -589,7 +617,7 @@ final class DatabaseManager: ObservableObject {
             return management.code
         }
         let items = try await fetchManagementData()
-        return items.first?.code
+        return items.first?.code ?? "1234"
     }
 
     func updateManagement(id: Int, code: String, address: String, welcome: String, youtube: URL?, kakao: URL?, notification: String, playwhen: [String], fee: Int, venmo: String) {


### PR DESCRIPTION
## Summary
- Avoid creating anonymous users on app launch
- Default to keycode `1234` when management data is unavailable instead of writing to Firestore

## Testing
- `xcodebuild -project JokguApplication.xcodeproj -scheme JokguApplication -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*
- `npm --prefix functions run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0a6829bb8833186fcb980c1d10b23