### PR TITLE
Switch login to phone authentication and update registration

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -451,6 +451,10 @@ final class DatabaseManager: ObservableObject {
         try await updateMember(id: id, fields: ["permit": permit])
     }
 
+    func updateSyncd(id: Int, syncd: Int) async throws {
+        try await updateMember(id: id, fields: ["syncd": syncd])
+    }
+
     func updateOrder(id: Int, order: Int) async throws {
         try await updateMember(id: id, fields: ["orderIndex": order])
     }


### PR DESCRIPTION
## Summary
- replace username/password login with SMS phone authentication and sync check
- verify existing members via SMS and mark accounts as registered
- streamline new member registration with default profile settings

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*
- `cd functions && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0ab9c2d108331a451db967bd99060