### PR TITLE
Fix phone auth login not finding registered members

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -186,7 +186,15 @@ struct LoginView: View {
                 if error == nil {
                     Task {
                         let digits = phoneNumber.filter { $0.isNumber }
-                        if let member = try? await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: digits), member.syncd == 1 {
+                        let candidates = [phoneNumber, digits]
+                        var fetchedMember: Member?
+                        for number in candidates {
+                            if let member = try? await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: number), member.syncd == 1 {
+                                fetchedMember = member
+                                break
+                            }
+                        }
+                        if let member = fetchedMember {
                             await MainActor.run {
                                 loggedInUser = member.username
                                 userPermit = member.permit


### PR DESCRIPTION
## Summary
- Ensure login verifies both formatted and digit-only phone numbers when fetching a member

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b06b3c3c8331906449d2b8b1b51d