### PR TITLE
Show message for unregistered phone auth login

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -183,7 +183,13 @@ struct LoginView: View {
         let credential = PhoneAuthProvider.provider().credential(withVerificationID: id, verificationCode: smsCode)
         Auth.auth().signIn(with: credential) { _, error in
             DispatchQueue.main.async {
-                if error == nil {
+                if let nsError = error as NSError? {
+                    if AuthErrorCode(rawValue: nsError.code) == .userNotFound {
+                        errorMessage = "Account has not been registered"
+                    } else {
+                        errorMessage = nsError.localizedDescription
+                    }
+                } else {
                     Task {
                         let digits = phoneNumber.filter { $0.isNumber }
                         let candidates = [phoneNumber, digits]
@@ -209,8 +215,6 @@ struct LoginView: View {
                             smsCode = ""
                         }
                     }
-                } else {
-                    errorMessage = error?.localizedDescription
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Display a specific error when phone auth login fails due to an unregistered account

## Testing
- `swift test 2>&1 | head -n 200` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b231e7f08331a41934c0bfbd00f6