### PR TITLE
Fix unsynced member list on verification screen

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -418,12 +418,13 @@ final class DatabaseManager: ObservableObject {
 
     func fetchUnsyncedMembers() async throws -> [Member] {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[Member], Error>) in
-            db.collection("member").whereField("syncd", isEqualTo: 0).getDocuments { snapshot, error in
+            db.collection("member").getDocuments { snapshot, error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else {
                     let items = snapshot?.documents.compactMap { self.memberFromDoc($0) } ?? []
-                    continuation.resume(returning: items)
+                    let unsynced = items.filter { $0.syncd == 0 }
+                    continuation.resume(returning: unsynced)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fetch all members from Firestore then filter by `syncd == 0` to populate MemberVerificationView

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b9aa247883319d84670c91422c3c