### PR TITLE
Show registration success after member verification

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -10,6 +10,7 @@ struct LoginView: View {
     @State private var verificationID: String? = nil
     @State private var isSendingCode = false
     @State private var errorMessage: String? = nil
+    @State private var successMessage: String? = nil
     @State private var showKeyCodePrompt: Bool = false
     @State private var keyCodeInput: String = ""
     @State private var showMemberVerifyView: Bool = false
@@ -86,6 +87,10 @@ struct LoginView: View {
                     Text(errorMessage)
                         .foregroundColor(.red)
                 }
+                if let successMessage = successMessage {
+                    Text(successMessage)
+                        .foregroundColor(.green)
+                }
             }
             .frame(maxHeight: .infinity, alignment: .top)
             .padding(.horizontal)
@@ -143,7 +148,9 @@ struct LoginView: View {
             .padding()
         }
         .sheet(isPresented: $showMemberVerifyView) {
-            MemberVerificationView()
+            MemberVerificationView(onVerificationSuccess: {
+                successMessage = "Registration completed"
+            })
         }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,14 +2,6 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /management/{docId} {
-      allow read, write: if request.auth != null;
-    }
-
-    match /member/{docId} {
-      allow read, write: if request.auth != null;
-    }
-
     match /{document=**} {
       allow read, write: if request.auth != null;
     }


### PR DESCRIPTION
## Summary
- Add callback to `MemberVerificationView` to notify login screen when a member is verified
- Surface a success message on `LoginView` after member verification
- Simplify Firestore security rules to a single database-wide rule

## Testing
- `xcodebuild -scheme JokguApplication test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bca8575c8331915ffa9640a61206