### PR TITLE
Create default management record when missing

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -62,6 +62,19 @@ final class DatabaseManager: ObservableObject {
             guard let snapshot = snapshot else { return }
 
             if snapshot.documents.isEmpty {
+                let fields: [String: Any] = [
+                    "id": 1,
+                    "keycode": "1234",
+                    "address": "",
+                    "welcome": "",
+                    "youtube": "",
+                    "kakao": "",
+                    "notification": "",
+                    "playwhen": [],
+                    "fee": 0,
+                    "venmo": ""
+                ]
+                self.db.collection("management").addDocument(data: fields)
                 let defaultKeyCode = KeyCode(
                     id: 1,
                     code: "1234",
@@ -591,6 +604,19 @@ final class DatabaseManager: ObservableObject {
                 } else {
                     let items = snapshot?.documents.compactMap { self.keyCodeFromDoc($0) } ?? []
                     if items.isEmpty {
+                        let fields: [String: Any] = [
+                            "id": 1,
+                            "keycode": "1234",
+                            "address": "",
+                            "welcome": "",
+                            "youtube": "",
+                            "kakao": "",
+                            "notification": "",
+                            "playwhen": [],
+                            "fee": 0,
+                            "venmo": ""
+                        ]
+                        self.db.collection("management").addDocument(data: fields)
                         let defaultKeyCode = KeyCode(
                             id: 1,
                             code: "1234",


### PR DESCRIPTION
## Summary
- Auto-create default management record with key code 1234 when none exists
- Ensure default management data is populated for listeners and fetches

## Testing
- `npm test` *(fails: Missing script "test")*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*
- `swiftc JokguApplication/Core/DatabaseManager.swift` *(fails: no such module 'FirebaseFirestore')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c95b4a14833196705f309d79ab9f