### PR TITLE
Create default management record when missing

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FirebaseCore
 import FirebaseFirestore
 import FirebaseStorage
 import CryptoKit
@@ -48,6 +49,9 @@ final class DatabaseManager: ObservableObject {
     private var memberUsernameRefCache: [String: DocumentReference] = [:]
 
     private init() {
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
         let firestore = Firestore.firestore()
         let settings = firestore.settings
         settings.cacheSettings = PersistentCacheSettings()
@@ -62,6 +66,19 @@ final class DatabaseManager: ObservableObject {
             guard let snapshot = snapshot else { return }
 
             if snapshot.documents.isEmpty {
+                let fields: [String: Any] = [
+                    "id": 1,
+                    "keycode": "1234",
+                    "address": "",
+                    "welcome": "",
+                    "youtube": "",
+                    "kakao": "",
+                    "notification": "",
+                    "playwhen": [],
+                    "fee": 0,
+                    "venmo": ""
+                ]
+                self.db.collection("management").addDocument(data: fields)
                 let defaultKeyCode = KeyCode(
                     id: 1,
                     code: "1234",
@@ -591,6 +608,19 @@ final class DatabaseManager: ObservableObject {
                 } else {
                     let items = snapshot?.documents.compactMap { self.keyCodeFromDoc($0) } ?? []
                     if items.isEmpty {
+                        let fields: [String: Any] = [
+                            "id": 1,
+                            "keycode": "1234",
+                            "address": "",
+                            "welcome": "",
+                            "youtube": "",
+                            "kakao": "",
+                            "notification": "",
+                            "playwhen": [],
+                            "fee": 0,
+                            "venmo": ""
+                        ]
+                        self.db.collection("management").addDocument(data: fields)
                         let defaultKeyCode = KeyCode(
                             id: 1,
                             code: "1234",

--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -130,11 +130,13 @@ struct LoginView: View {
                     Spacer()
 
                     Button("Confirm") {
-                        let storedCode = databaseManager.management?.code ?? ""
-                        if keyCodeInput == storedCode {
-                            showKeyCodePrompt = false
-                            keyCodeInput = ""
-                            showMemberVerifyView = true
+                        Task {
+                            let storedCode = (try? await databaseManager.fetchKeyCode()) ?? "1234"
+                            if keyCodeInput == storedCode {
+                                showKeyCodePrompt = false
+                                keyCodeInput = ""
+                                showMemberVerifyView = true
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Auto-create default management record with key code 1234 when none exists
- Fetch key code during login verification to seed default management data
- Ensure Firebase is configured before initializing Firestore for reliable backend communication

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*
- `xcodebuild -list` *(fails: command not found)*
- `swiftc JokguApplication/Core/DatabaseManager.swift` *(fails: no such module 'FirebaseCore')*

------
https://chatgpt.com/codex/tasks/task_e_68b0c95b4a14833196705f309d79ab9f