### PR TITLE
Implement automatic auth login and proper logout

### DIFF
--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Foundation
 import UIKit
 import UserNotifications
+import FirebaseAuth
 
 struct HomeView: View {
     @Binding var isLoggedIn: Bool
@@ -105,6 +106,7 @@ struct HomeView: View {
                     }
 
                     Button {
+                        try? Auth.auth().signOut()
                         username = ""
                         isLoggedIn = false
                     } label: {


### PR DESCRIPTION
## Summary
- Auto-login users on app start when Firebase authentication exists
- Refine login flow to keep session only for verified members and sign out otherwise
- Sign out from Firebase when using the app's logout action

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e032d394833189d11a18f3f2b32c