### PR TITLE
Create default tables during phone login

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -202,6 +202,7 @@ struct LoginView: View {
                             }
                         }
                         if let member = fetchedMember {
+                            await databaseManager.createTablesIfNeeded(for: member.username)
                             await MainActor.run {
                                 loggedInUser = member.username
                                 userPermit = member.permit
@@ -247,6 +248,7 @@ struct LoginView: View {
         let candidates = [phone, digits]
         for number in candidates {
             if let member = try? await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: number), member.syncd == 1 {
+                await databaseManager.createTablesIfNeeded(for: member.username)
                 await MainActor.run {
                     loggedInUser = member.username
                     userPermit = member.permit


### PR DESCRIPTION
## Summary
- add `createTablesIfNeeded` to `DatabaseManager` to seed Firestore collections with defaults
- invoke default table creation after phone authentication in manual and automatic login flows

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e1d6374883319a1dd5988fbdeb5e