### PR TITLE
Fix member verification phone number formatting

### DIFF
--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -38,7 +38,16 @@ struct MemberVerificationView: View {
                         if let member = selectedMember {
                             isSendingCode = true
                             let digits = member.phoneNumber.filter { $0.isNumber }
-                            let phone = digits.hasPrefix("1") ? "+" + digits : "+1" + digits
+                            let phone: String
+                            if digits.count == 10 {
+                                phone = "+1" + digits
+                            } else if digits.count == 11 && digits.hasPrefix("1") {
+                                phone = "+" + digits
+                            } else {
+                                isSendingCode = false
+                                errorMessage = "Invalid phone number format"
+                                return
+                            }
                             PhoneAuthProvider.provider().verifyPhoneNumber(phone, uiDelegate: nil) { id, error in
                                 DispatchQueue.main.async {
                                     isSendingCode = false


### PR DESCRIPTION
## Summary
- Ensure member phone numbers are formatted to E.164 during verification
- Provide error feedback for invalid stored numbers

## Testing
- `xcodebuild -list -project JokguApplication.xcodeproj` *(command not found)*
- `swift test` *(could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e48078dc8331ad378c88880f1760