### PR TITLE
Restrict auto login to LoginView

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -154,7 +154,9 @@ struct LoginView: View {
             }
             .padding()
         }
-        .sheet(isPresented: $showMemberVerifyView) {
+        .sheet(isPresented: $showMemberVerifyView, onDismiss: {
+            Task { await autoLoginIfPossible() }
+        }) {
             MemberVerificationView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, loggedInUser: $loggedInUser)
         }
         .onAppear {

--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -127,9 +127,6 @@ struct MemberVerificationView: View {
                                                 verifyingMember = nil
                                                 inputCode = ""
                                                 verificationID = nil
-                                                loggedInUser = member.username
-                                                userPermit = member.permit
-                                                isLoggedIn = true
                                             }
                                             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                                                 dismiss()

--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -153,11 +153,6 @@ struct RegisterView: View {
             await DatabaseManager.shared.createTablesIfNeeded(for: username)
             await MainActor.run {
                 showMessage("Registration Complete", color: .green)
-                if let member = member {
-                    loggedInUser = member.username
-                    userPermit = member.permit
-                }
-                isLoggedIn = true
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 onComplete?()


### PR DESCRIPTION
## Summary
- Prevent MemberVerificationView and RegisterView from marking users as logged in so phone-authenticated users return to LoginView first.
- Trigger automatic sign-in only when LoginView appears or when verification sheet dismisses.

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e98b22cc8331b418e3d7c80eadb8