### PR TITLE
Add account deletion to profile view

### DIFF
--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -77,7 +77,7 @@ struct HomeView: View {
                     }
                     .buttonStyle(HomeButtonStyle())
                     .sheet(isPresented: $showProfile) {
-                        ProfileView(username: username)
+                        ProfileView(username: $username, isLoggedIn: $isLoggedIn, userPermit: $userPermit)
                     }
                     .padding(.horizontal)
 


### PR DESCRIPTION
## Summary
- Enable account deletion from ProfileView with confirmation and cleanup of authentication and keychain state.
- Pass login state bindings from HomeView to ProfileView to handle account removal properly.

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f0faf8008331ab127846ff503927