### PR TITLE
Remove legacy username/password fields

### DIFF
--- a/JokguApplication/Core/ContentView.swift
+++ b/JokguApplication/Core/ContentView.swift
@@ -3,13 +3,13 @@ import SwiftUI
 struct ContentView: View {
     @State private var isLoggedIn: Bool = false
     @State private var userPermit: Int = 0
-    @State private var username: String = ""
+    @State private var phoneNumber: String = ""
 
     var body: some View {
         if isLoggedIn {
-            HomeView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, username: $username)
+            HomeView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, phoneNumber: $phoneNumber)
         } else {
-            LoginView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, loggedInUser: $username)
+            LoginView(isLoggedIn: $isLoggedIn, userPermit: $userPermit, loggedInUser: $phoneNumber)
         }
     }
 }

--- a/JokguApplication/Core/TodayPrompt.swift
+++ b/JokguApplication/Core/TodayPrompt.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 extension View {
-    func todayPrompt(isPresented: Binding<Bool>, username: String, onDecision: (() -> Void)? = nil) -> some View {
+    func todayPrompt(isPresented: Binding<Bool>, phoneNumber: String, onDecision: (() -> Void)? = nil) -> some View {
         self.alert("Jokgu Today—YOU IN?", isPresented: isPresented) {
             Button("Yes") {
                 Task {
-                    try? await DatabaseManager.shared.updateToday(username: username, value: 1)
+                    try? await DatabaseManager.shared.updateToday(phoneNumber: phoneNumber, value: 1)
                     await MainActor.run {
                         isPresented.wrappedValue = false
                         onDecision?()
@@ -14,7 +14,7 @@ extension View {
             }
             Button("No") {
                 Task {
-                    try? await DatabaseManager.shared.updateToday(username: username, value: 2)
+                    try? await DatabaseManager.shared.updateToday(phoneNumber: phoneNumber, value: 2)
                     await MainActor.run {
                         isPresented.wrappedValue = false
                         onDecision?()

--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -7,7 +7,7 @@ import FirebaseAuth
 struct HomeView: View {
     @Binding var isLoggedIn: Bool
     @Binding var userPermit: Int
-    @Binding var username: String
+    @Binding var phoneNumber: String
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var databaseManager: DatabaseManager
     @State private var showManagement = false
@@ -55,7 +55,7 @@ struct HomeView: View {
                     }
                     .buttonStyle(HomeButtonStyle())
                     .sheet(isPresented: $showLineup) {
-                        LineupView(username: username)
+                        LineupView(phoneNumber: phoneNumber)
                     }
                     .padding(.horizontal)
 
@@ -77,7 +77,7 @@ struct HomeView: View {
                     }
                     .buttonStyle(HomeButtonStyle())
                     .sheet(isPresented: $showProfile) {
-                        ProfileView(username: $username, isLoggedIn: $isLoggedIn, userPermit: $userPermit)
+                        ProfileView(phoneNumber: $phoneNumber, isLoggedIn: $isLoggedIn, userPermit: $userPermit)
                     }
                     .padding(.horizontal)
 
@@ -88,7 +88,7 @@ struct HomeView: View {
                     }
                     .buttonStyle(HomeButtonStyle())
                     .sheet(isPresented: $showPayment) {
-                        PaymentView(username: username)
+                        PaymentView(phoneNumber: phoneNumber)
                     }
                     .padding(.horizontal)
 
@@ -110,7 +110,7 @@ struct HomeView: View {
                         KeychainManager.shared.delete("loggedInUser")
                         KeychainManager.shared.delete("userPermit")
                         KeychainManager.shared.delete("faceIDEnabled")
-                        username = ""
+                        phoneNumber = ""
                         isLoggedIn = false
                     } label: {
                         Label("Logout", systemImage: "rectangle.portrait.and.arrow.right")
@@ -134,7 +134,7 @@ struct HomeView: View {
         .onChange(of: databaseManager.management?.id) { _, _ in
             checkTodayStatus()
         }
-        .todayPrompt(isPresented: $showTodayPrompt, username: username)
+        .todayPrompt(isPresented: $showTodayPrompt, phoneNumber: phoneNumber)
     }
 
     private func formatNotification(_ text: String) -> AttributedString {
@@ -179,7 +179,7 @@ struct HomeView: View {
             let todayName = formatter.string(from: Date())
             if let management = databaseManager.management,
                management.playwhen.contains(todayName),
-               let user = try? await DatabaseManager.shared.fetchUser(username: username),
+               let user = try? await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: phoneNumber),
                user.today == 0 {
                 await MainActor.run { showTodayPrompt = true }
             }
@@ -202,6 +202,6 @@ private struct HomeButtonStyle: ButtonStyle {
 }
 
 #Preview {
-    HomeView(isLoggedIn: .constant(true), userPermit: .constant(1), username: .constant("USER"))
+    HomeView(isLoggedIn: .constant(true), userPermit: .constant(1), phoneNumber: .constant("USER"))
         .environmentObject(DatabaseManager.shared)
 }

--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -222,12 +222,12 @@ struct LoginView: View {
                             }
                         }
                         if let member = fetchedMember {
-                            await databaseManager.createTablesIfNeeded(for: member.username)
+                            await databaseManager.createTablesIfNeeded(for: member.phoneNumber)
                             await MainActor.run {
-                                loggedInUser = member.username
+                                loggedInUser = member.phoneNumber
                                 userPermit = member.permit
                                 isLoggedIn = true
-                                KeychainManager.shared.save(member.username, for: "loggedInUser")
+                                KeychainManager.shared.save(member.phoneNumber, for: "loggedInUser")
                                 KeychainManager.shared.save(String(member.permit), for: "userPermit")
                                 KeychainManager.shared.save(enableFaceID ? "true" : "false", for: "faceIDEnabled")
                             }
@@ -286,9 +286,9 @@ struct LoginView: View {
         let candidates = [phone, digits]
         for number in candidates {
             if let member = try? await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: number), member.syncd == 1 {
-                await databaseManager.createTablesIfNeeded(for: member.username)
+                await databaseManager.createTablesIfNeeded(for: member.phoneNumber)
                 await MainActor.run {
-                    loggedInUser = member.username
+                    loggedInUser = member.phoneNumber
                     userPermit = member.permit
                     isLoggedIn = true
                 }

--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -121,9 +121,9 @@ struct MemberVerificationView: View {
                                     Task {
                                         do {
                                             try await DatabaseManager.shared.updateSyncd(id: member.id, syncd: 1)
-                                            await DatabaseManager.shared.createTablesIfNeeded(for: member.username)
+                                            await DatabaseManager.shared.createTablesIfNeeded(for: member.phoneNumber)
                                             await MainActor.run {
-                                                loggedInUser = member.username
+                                                loggedInUser = member.phoneNumber
                                                 userPermit = member.permit
                                                 isLoggedIn = true
                                                 showMessage("Registration Complete", color: .green)

--- a/JokguApplication/EntryViews/RegisterView.swift
+++ b/JokguApplication/EntryViews/RegisterView.swift
@@ -138,21 +138,19 @@ struct RegisterView: View {
         let trimmedLast = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPhone = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let dob = dob else { return }
-        let username = trimmedPhone.filter { $0.isNumber }
         do {
+            let phoneDigits = trimmedPhone.filter { $0.isNumber }
             try await DatabaseManager.shared.insertUser(
-                username: username,
-                password: UUID().uuidString,
                 firstName: trimmedFirst,
                 lastName: trimmedLast,
-                phoneNumber: trimmedPhone,
+                phoneNumber: phoneDigits,
                 dob: dateFormatter.string(from: dob),
                 picture: UIImage(named: "default-profile")?.pngData()
             )
             let member = try await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: trimmedPhone)
-            await DatabaseManager.shared.createTablesIfNeeded(for: username)
+            await DatabaseManager.shared.createTablesIfNeeded(for: phoneDigits)
             await MainActor.run {
-                loggedInUser = member?.username ?? username
+                loggedInUser = member?.phoneNumber ?? phoneDigits
                 userPermit = member?.permit ?? 0
                 isLoggedIn = true
                 showMessage("Registration Complete", color: .green)

--- a/JokguApplication/PostHomeViews/AllUsers/LineupView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/LineupView.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 struct LineupView: View {
     @Environment(\.dismiss) var dismiss
-    var username: String
+    var phoneNumber: String
     @State private var members: [Member] = []
     @State private var showTodayPrompt = false
     @State private var isPlayDay = false
     private let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
     private var userInLineup: Bool {
-        members.contains { $0.username.uppercased() == username.uppercased() }
+        members.contains { $0.phoneNumber.uppercased() == phoneNumber.uppercased() }
     }
 
     var body: some View {
@@ -90,7 +90,7 @@ struct LineupView: View {
                     checkPlayDay()
                 }
             }
-            .todayPrompt(isPresented: $showTodayPrompt, username: username) {
+            .todayPrompt(isPresented: $showTodayPrompt, phoneNumber: phoneNumber) {
                 Task {
                     if let fetched = try? await DatabaseManager.shared.fetchTodayMembers() {
                         await MainActor.run { members = fetched }
@@ -120,5 +120,5 @@ private extension LineupView {
 }
 
 #Preview {
-    LineupView(username: "USER")
+    LineupView(phoneNumber: "USER")
 }

--- a/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/MemberView.swift
@@ -99,9 +99,6 @@ struct MemberView: View {
                             Text("DOB: \(member.dob)")
                             Text("Phone: \(member.phoneNumber)")
                             Text("Attendance: \(member.attendance)")
-                            if userPermit == 2 {
-                                Text("Recovery: \(member.recovery)")
-                            }
                             if userPermit == 9 || userPermit == 2 {
                                 Toggle("Guest", isOn: Binding(
                                     get: { members[index].guest == 1 },
@@ -171,7 +168,7 @@ struct MemberView: View {
                 case .delete:
                     return Alert(
                         title: Text("Confirm Delete"),
-                        message: Text("Are you sure you want to delete \(selectedMember?.username ?? "this user")?"),
+                        message: Text("Are you sure you want to delete \(selectedMember?.phoneNumber ?? "this user")?"),
                         primaryButton: .destructive(Text("Delete")) {
                             if let member = selectedMember, member.permit != 2 {
                                 Task { try? await DatabaseManager.shared.deleteUser(id: member.id) }
@@ -182,7 +179,7 @@ struct MemberView: View {
                 case .permit:
                     return Alert(
                         title: Text("Confirm Permit Change"),
-                        message: Text("Change permit to \(newPermit) for \(selectedMember?.username ?? "user")?"),
+                        message: Text("Change permit to \(newPermit) for \(selectedMember?.phoneNumber ?? "user")?"),
                         primaryButton: .default(Text("Update")) {
                             if let member = selectedMember, member.permit != 2 {
                                 Task { try? await DatabaseManager.shared.updatePermit(id: member.id, permit: newPermit) }

--- a/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/PaymentView.swift
@@ -5,7 +5,7 @@ struct PaymentView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.openURL) private var openURL
     
-    let username: String
+    let phoneNumber: String
     @State private var fields: [Int] = Array(repeating: 0, count: 12)
     @State private var fee: Int = 0
     @State private var selectedIndices: Set<Int> = []
@@ -111,7 +111,7 @@ struct PaymentView: View {
 
     private func loadData() {
         Task {
-            if let fetched = await DatabaseManager.shared.fetchUserFields(username: username) {
+            if let fetched = await DatabaseManager.shared.fetchUserFields(phoneNumber: phoneNumber) {
                 var filled = Array(repeating: 0, count: 12)
                 for i in 0..<min(fetched.count, 12) {
                     filled[i] = fetched[i]
@@ -133,7 +133,7 @@ struct PaymentView: View {
 
         let handle = normalizeHandle(venmoAccount)
         let monthsSummary = monthNoteSummary()
-        let base = "Jokgu fee for \(username)"
+        let base = "Jokgu fee for \(phoneNumber)"
         let note = monthsSummary.isEmpty ? base : "\(base) — \(monthsSummary)"
 
         guard let appURL = makeVenmoAppURL(recipient: handle, amount: dollars, note: note) else {
@@ -214,5 +214,5 @@ struct PaymentView: View {
 }
 
 #Preview {
-    PaymentView(username: "USER")
+    PaymentView(phoneNumber: "USER")
 }

--- a/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
+++ b/JokguApplication/PostHomeViews/ProUsers/PayStatusView.swift
@@ -68,20 +68,20 @@ struct PayStatusView: View {
             ForEach(members) { member in
                 let binding = Binding<String>(
                     get: {
-                        let fields = userFields[member.username] ?? Array(repeating: "", count: months.count)
+                        let fields = userFields[member.phoneNumber] ?? Array(repeating: "", count: months.count)
                         return monthIndex < fields.count ? fields[monthIndex] : ""
                     },
                     set: { newValue in
                         guard userPermit == 9 || userPermit == 2 else { return }
-                        var fields = userFields[member.username] ?? Array(repeating: "", count: months.count)
+                        var fields = userFields[member.phoneNumber] ?? Array(repeating: "", count: months.count)
                         if fields.count < months.count {
                             fields += Array(repeating: "", count: months.count - fields.count)
                         }
                         fields[monthIndex] = newValue
-                        userFields[member.username] = fields
+                        userFields[member.phoneNumber] = fields
                         let intFields = fields.map { Int($0) ?? 0 }
                         Task {
-                            _ = await DatabaseManager.shared.saveUserFields(username: member.username, fields: intFields)
+                            _ = await DatabaseManager.shared.saveUserFields(phoneNumber: member.phoneNumber, fields: intFields)
                         }
                     }
                 )
@@ -117,14 +117,14 @@ struct PayStatusView: View {
                 let filtered = fetched.filter { $0.guest == 1 }
                 var dict: [String: [String]] = [:]
                 for member in filtered {
-                    if let values = await DatabaseManager.shared.fetchUserFields(username: member.username) {
+                    if let values = await DatabaseManager.shared.fetchUserFields(phoneNumber: member.phoneNumber) {
                         var strings = values.map { String($0) }
                         if strings.count < months.count {
                             strings += Array(repeating: "", count: months.count - strings.count)
                         }
-                        dict[member.username] = strings
+                        dict[member.phoneNumber] = strings
                     } else {
-                        dict[member.username] = Array(repeating: "", count: months.count)
+                        dict[member.phoneNumber] = Array(repeating: "", count: months.count)
                     }
                 }
                 let managements = try await DatabaseManager.shared.fetchManagementData()
@@ -146,7 +146,7 @@ struct PayStatusView: View {
         for monthIndex in 0..<months.count {
             var row = months[monthIndex]
             for member in members {
-                let fields = userFields[member.username] ?? Array(repeating: "", count: months.count)
+                let fields = userFields[member.phoneNumber] ?? Array(repeating: "", count: months.count)
                 let value = monthIndex < fields.count ? fields[monthIndex] : ""
                 row += ",\(value)"
             }

--- a/dataconnect/example/mutations.gql
+++ b/dataconnect/example/mutations.gql
@@ -6,10 +6,10 @@
 #   movie_insert(data: { title: $title, genre: $genre, imageUrl: $imageUrl })
 # }
 
-# # Upsert (update or insert) a user's username based on their auth.uid
-# mutation UpsertUser($username: String!) @auth(level: USER) {
+# # Upsert (update or insert) a user's phone number based on their auth.uid
+# mutation UpsertUser($phoneNumber: String!) @auth(level: USER) {
 #   # The "auth.uid" server value ensures that users can only register their own user.
-#   user_upsert(data: { id_expr: "auth.uid", username: $username })
+#   user_upsert(data: { id_expr: "auth.uid", phoneNumber: $phoneNumber })
 # }
 
 # # Add a review for a movie

--- a/dataconnect/example/queries.gql
+++ b/dataconnect/example/queries.gql
@@ -15,7 +15,7 @@
 # query ListUsers @auth(level: NO_ACCESS) {
 #   users {
 #     id
-#     username
+#     phoneNumber
 #   }
 # }
 
@@ -24,7 +24,7 @@
 # query ListUserReviews @auth(level: USER) {
 #   user(key: { id_expr: "auth.uid" }) {
 #     id
-#     username
+#     phoneNumber
 #     # <field>_on_<foreign_key_field> makes it easy to grab info from another table
 #     # Here, we use it to grab all the reviews written by the user.
 #     reviews: reviews_on_user {
@@ -57,7 +57,7 @@
 #       rating
 #       user {
 #         id
-#         username
+#         phoneNumber
 #       }
 #     }
 #   }

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -4,7 +4,7 @@
 # type User @table {
 #   # `@default(expr: "auth.uid")` sets it to Firebase Auth UID during insert and upsert.
 #   id: String! @default(expr: "auth.uid")
-#   username: String! @col(dataType: "varchar(50)")
+#   phoneNumber: String! @col(dataType: "varchar(50)")
 #   # The `user: User!` field in the Review table generates the following one-to-many query field.
 #   #  reviews_on_user: [Review!]!
 #   # The `Review` join table the following many-to-many query field.

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <h2>What we collect</h2>
     <p>The App is intended for approved club members. During registration and use we may collect:</p>
     <ul>
-      <li>Account information (e.g., name, username, phone number, birthday)</li>
+      <li>Account information (e.g., name, phone number, birthday)</li>
       <li>Club participation data (attendance, game sign‑ups) and dues status</li>
       <li>Basic diagnostics or crash logs to improve the App</li>
     </ul>


### PR DESCRIPTION
## Summary
- drop username, password, and recovery fields in favor of phone-number-only auth
- refactor profile, home, and registration flows to use phone numbers
- clean up docs and examples referencing usernames

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fb4eb8288331b64e353087221eb7