### PR TITLE
Simplify phone auth error message

### DIFF
--- a/JokguApplication/EntryViews/LoginView.swift
+++ b/JokguApplication/EntryViews/LoginView.swift
@@ -199,7 +199,11 @@ struct LoginView: View {
                 if let id = id {
                     verificationID = id
                 } else if let error = error {
-                    showError(error.localizedDescription)
+                    if let code = AuthErrorCode(rawValue: (error as NSError).code), code == .invalidPhoneNumber {
+                        showError("Invalid phone number. Please check the number and try again.")
+                    } else {
+                        showError("Failed to send verification code. Please try again.")
+                    }
                 }
             }
         }
@@ -232,7 +236,7 @@ struct LoginView: View {
                                 KeychainManager.shared.save(enableFaceID ? "true" : "false", for: "faceIDEnabled")
                             }
                         } else {
-                            await MainActor.run { showError("Phone number not registered. Please verify or register.") }
+                            await MainActor.run { showError("No account found for this phone number.") }
                             try? Auth.auth().signOut()
                         }
                         await MainActor.run {


### PR DESCRIPTION
## Summary
- replace verbose phone auth errors with concise messages
- fix AuthErrorCode usage for phone number validation

## Testing
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b20791b9bc833186e1473657a146a5