### PR TITLE
Use original member list for verification

### DIFF
--- a/JokguApplication/Core/DatabaseManager.swift
+++ b/JokguApplication/Core/DatabaseManager.swift
@@ -33,6 +33,17 @@ struct Member: Identifiable {
     var orderIndex: Int
 }
 
+struct OriginalMember: Identifiable {
+    let id: String
+    var firstName: String
+    var lastName: String
+    var phoneNumber: String
+    var dob: String
+    var permit: Int
+    var guest: Int
+    var syncd: Int
+}
+
 struct UserFields {
     let phoneNumber: String
     var values: [Int]
@@ -136,6 +147,18 @@ final class DatabaseManager: ObservableObject {
         return Member(id: id, firstName: firstName, lastName: lastName, phoneNumber: phoneNumber, dob: dob, pictureURL: pictureURL, attendance: attendance, permit: permit, guest: guest, today: today, syncd: syncd, orderIndex: orderIndex)
     }
 
+    private func originalMemberFromDoc(_ doc: DocumentSnapshot) -> OriginalMember? {
+        guard let data = doc.data() else { return nil }
+        let firstName = data["firstname"] as? String ?? ""
+        let lastName = data["lastname"] as? String ?? ""
+        let phoneNumber = data["phonenumber"] as? String ?? ""
+        let dob = data["dob"] as? String ?? ""
+        let permit = data["permit"] as? Int ?? 0
+        let guest = data["guest"] as? Int ?? 0
+        let syncd = data["syncd"] as? Int ?? 0
+        return OriginalMember(id: doc.documentID, firstName: firstName, lastName: lastName, phoneNumber: phoneNumber, dob: dob, permit: permit, guest: guest, syncd: syncd)
+    }
+
     private func keyCodeFromDoc(_ doc: DocumentSnapshot) -> KeyCode? {
         guard let data = doc.data() else { return nil }
         let id = data["id"] as? Int ?? 0
@@ -212,7 +235,7 @@ final class DatabaseManager: ObservableObject {
         }
     }
 
-    func insertUser(firstName: String, lastName: String, phoneNumber: String, dob: String, picture: Data?) async throws {
+    func insertUser(firstName: String, lastName: String, phoneNumber: String, dob: String, picture: Data?, permit: Int = 0, guest: Int = 0) async throws {
         try requireAuth()
         guard try await !userExists(phoneNumber) else { throw NSError(domain: "UserExists", code: 1) }
 
@@ -267,8 +290,8 @@ final class DatabaseManager: ObservableObject {
             "phonenumber": phoneNumber,
             "dob": dob,
             "attendance": 0,
-            "permit": 0,
-            "guest": 0,
+            "permit": permit,
+            "guest": guest,
             "today": 0,
             "syncd": 1,
             "orderIndex": newId
@@ -369,6 +392,19 @@ final class DatabaseManager: ObservableObject {
         }
     }
 
+    func fetchUnsyncedOriginalMembers() async throws -> [OriginalMember] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[OriginalMember], Error>) in
+            db.collection("original_member").whereField("syncd", isEqualTo: 0).getDocuments { snapshot, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    let items = snapshot?.documents.compactMap { self.originalMemberFromDoc($0) } ?? []
+                    continuation.resume(returning: items)
+                }
+            }
+        }
+    }
+
     // MARK: - Updates
     private func updateMember(id: Int, fields: [String: Any]) async throws {
         try requireAuth()
@@ -394,6 +430,20 @@ final class DatabaseManager: ObservableObject {
 
     func updateSyncd(id: Int, syncd: Int) async throws {
         try await updateMember(id: id, fields: ["syncd": syncd])
+    }
+
+    func updateOriginalSyncd(id: String, syncd: Int) async throws {
+        try requireAuth()
+        let ref = db.collection("original_member").document(id)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            ref.updateData(["syncd": syncd]) { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
     }
 
     func updateOrder(id: Int, order: Int) async throws {

--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -6,10 +6,10 @@ struct MemberVerificationView: View {
     @Binding var isLoggedIn: Bool
     @Binding var userPermit: Int
     @Binding var loggedInUser: String
-    @State private var members: [Member] = []
-    @State private var selectedMember: Member? = nil
+    @State private var members: [OriginalMember] = []
+    @State private var selectedMember: OriginalMember? = nil
     @State private var showRegister = false
-    @State private var verifyingMember: Member? = nil
+    @State private var verifyingMember: OriginalMember? = nil
     @State private var inputCode: String = ""
     @State private var verificationID: String? = nil
     @State private var isSendingCode = false
@@ -83,14 +83,14 @@ struct MemberVerificationView: View {
         }
         .onAppear {
             Task {
-                if let fetched = try? await DatabaseManager.shared.fetchUnsyncedMembers() {
+                if let fetched = try? await DatabaseManager.shared.fetchUnsyncedOriginalMembers() {
                     await MainActor.run { members = fetched }
                 }
             }
         }
         .sheet(isPresented: $showRegister, onDismiss: {
             Task {
-                if let fetched = try? await DatabaseManager.shared.fetchUnsyncedMembers() {
+                if let fetched = try? await DatabaseManager.shared.fetchUnsyncedOriginalMembers() {
                     await MainActor.run { members = fetched }
                 }
             }
@@ -120,7 +120,8 @@ struct MemberVerificationView: View {
                                 if error == nil {
                                     Task {
                                         do {
-                                            try await DatabaseManager.shared.updateSyncd(id: member.id, syncd: 1)
+                                            try await DatabaseManager.shared.updateOriginalSyncd(id: member.id, syncd: 1)
+                                            try await DatabaseManager.shared.insertUser(firstName: member.firstName, lastName: member.lastName, phoneNumber: member.phoneNumber, dob: member.dob, picture: nil, permit: member.permit, guest: member.guest)
                                             await DatabaseManager.shared.createTablesIfNeeded(for: member.phoneNumber)
                                             await MainActor.run {
                                                 loggedInUser = member.phoneNumber


### PR DESCRIPTION
## Summary
- update database helpers to pull and sync records from `original_member`
- member verification lists unsynced originals, verifies via stored phone number, then inserts into `member`

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `npm test` *(fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/JokguApplication/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b285bcf4f083318e129644ad69a648