### PR TITLE
Set default profile picture during member verification

### DIFF
--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -121,7 +121,7 @@ struct MemberVerificationView: View {
                                     Task {
                                         do {
                                             try await DatabaseManager.shared.updateOriginalSyncd(id: member.id, syncd: 1)
-                                            try await DatabaseManager.shared.insertUser(firstName: member.firstName, lastName: member.lastName, phoneNumber: member.phoneNumber, dob: member.dob, picture: nil, permit: member.permit, guest: member.guest)
+                                            try await DatabaseManager.shared.insertUser(firstName: member.firstName, lastName: member.lastName, phoneNumber: member.phoneNumber, dob: member.dob, picture: UIImage(named: "default-profile")?.pngData(), permit: member.permit, guest: member.guest)
                                             await DatabaseManager.shared.createTablesIfNeeded(for: member.phoneNumber)
                                             await MainActor.run {
                                                 loggedInUser = member.phoneNumber


### PR DESCRIPTION
## Summary
- Ensure MemberVerificationView assigns the default profile image when creating a verified user

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a332ce3c83319628a3ac0398f09d