### PR TITLE
Assign default profile image on user verification

### DIFF
--- a/JokguApplication/EntryViews/MemberVerificationView.swift
+++ b/JokguApplication/EntryViews/MemberVerificationView.swift
@@ -124,6 +124,19 @@ struct MemberVerificationView: View {
                                             let existing = try await DatabaseManager.shared.fetchMemberByPhoneNumber(phoneNumber: member.phoneNumber)
                                             let target = existing ?? member
 
+                                            if target.pictureURL == nil || target.pictureURL?.isEmpty == true {
+                                                if let data = UIImage(named: "default-profile")?.pngData() {
+                                                    try await DatabaseManager.shared.updateUser(
+                                                        currentPhoneNumber: target.phoneNumber,
+                                                        firstName: target.firstName,
+                                                        lastName: target.lastName,
+                                                        newPhoneNumber: target.phoneNumber,
+                                                        dob: target.dob,
+                                                        picture: data
+                                                    )
+                                                }
+                                            }
+
                                             try await DatabaseManager.shared.updateSyncd(id: target.id, syncd: 1)
                                             await DatabaseManager.shared.createTablesIfNeeded(for: target.phoneNumber)
 


### PR DESCRIPTION
## Summary
- Ensure MemberVerificationView assigns a default profile image for verified users without a profile picture

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aff2f3c883318b762917b37f923d