### PR TITLE
Add export option plists for CI builds

### DIFF
--- a/ci/ad-hoc-exportoptions.plist
+++ b/ci/ad-hoc-exportoptions.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>ad-hoc</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>incho.JokguApplication</key>
+        <string>JokguApplication Ad Hoc</string>
+    </dict>
+</dict>
+</plist>

--- a/ci/app-store-exportoptions.plist
+++ b/ci/app-store-exportoptions.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>incho.JokguApplication</key>
+        <string>JokguApplication App Store</string>
+    </dict>
+    <key>uploadBitcode</key>
+    <false/>
+</dict>
+</plist>

--- a/ci/development-exportoptions.plist
+++ b/ci/development-exportoptions.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>incho.JokguApplication</key>
+        <string>JokguApplication Development</string>
+    </dict>
+</dict>
+</plist>

--- a/ci/export.sh
+++ b/ci/export.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCHEME=${SCHEME:-JokguApplication}
+ARCHIVE_PATH=${ARCHIVE_PATH:-build/${SCHEME}.xcarchive}
+EXPORT_DIR=${EXPORT_DIR:-build/export}
+METHOD=${METHOD:-development}
+PLIST="ci/${METHOD}-exportoptions.plist"
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportPath "$EXPORT_DIR" \
+  -exportOptionsPlist "$PLIST"


### PR DESCRIPTION
## Summary
- add ad-hoc, development, and app-store export option plists
- provide CI export script referencing these plists

## Testing
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3454d8eb8833199efcb551999d50d