### PR TITLE
Switch CI export plists to automatic signing

### DIFF
--- a/ci/ad-hoc-exportoptions.plist
+++ b/ci/ad-hoc-exportoptions.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>ad-hoc</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+</dict>
+</plist>

--- a/ci/app-store-exportoptions.plist
+++ b/ci/app-store-exportoptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>uploadBitcode</key>
+    <false/>
+</dict>
+</plist>

--- a/ci/development-exportoptions.plist
+++ b/ci/development-exportoptions.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+</dict>
+</plist>

--- a/ci/export.sh
+++ b/ci/export.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCHEME=${SCHEME:-JokguApplication}
+ARCHIVE_PATH=${ARCHIVE_PATH:-build/${SCHEME}.xcarchive}
+EXPORT_DIR=${EXPORT_DIR:-build/export}
+METHOD=${METHOD:-development}
+PLIST="ci/${METHOD}-exportoptions.plist"
+
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportPath "$EXPORT_DIR" \
+  -exportOptionsPlist "$PLIST"


### PR DESCRIPTION
## Summary
- switch ad-hoc export plist to automatic signing
- switch development export plist to automatic signing
- switch App Store export plist to automatic signing

## Testing
- `npm --prefix functions run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3454d8eb8833199efcb551999d50d