### PR TITLE
Add Face ID usage description to Info.plist

### DIFF
--- a/JokguApplication/Info.plist
+++ b/JokguApplication/Info.plist
@@ -23,6 +23,8 @@
         <string>This app requires photo library access to select and upload media.</string>
         <key>NSCameraUsageDescription</key>
         <string>This app requires camera access to capture photos and videos.</string>
+        <key>NSFaceIDUsageDescription</key>
+        <string>This app uses Face ID for secure authentication.</string>
         <key>UIBackgroundModes</key>
         <array>
                 <string>remote-notification</string>


### PR DESCRIPTION
## Summary
- Add missing `NSFaceIDUsageDescription` to Info.plist to prevent launch crashes when Face ID is used

## Testing
- `xcodebuild -project JokguApplication.xcodeproj -scheme JokguApplication -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*
- `cd functions && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b77f422ab08331bc235bfce8eb0a86