### PR TITLE
Remove Face ID login functionality

### DIFF
--- a/JokguApplication/EntryViews/HomeView.swift
+++ b/JokguApplication/EntryViews/HomeView.swift
@@ -110,7 +110,6 @@ struct HomeView: View {
                         try? Auth.auth().signOut()
                         KeychainManager.shared.delete("loggedInUser")
                         KeychainManager.shared.delete("userPermit")
-                        KeychainManager.shared.delete("faceIDEnabled")
                         phoneNumber = ""
                         isLoggedIn = false
                     } label: {

--- a/JokguApplication/Info.plist
+++ b/JokguApplication/Info.plist
@@ -23,8 +23,6 @@
         <string>This app requires photo library access to select and upload media.</string>
         <key>NSCameraUsageDescription</key>
         <string>This app requires camera access to capture photos and videos.</string>
-        <key>NSFaceIDUsageDescription</key>
-        <string>This app uses Face ID for secure authentication.</string>
         <key>UIBackgroundModes</key>
         <array>
                 <string>remote-notification</string>

--- a/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
+++ b/JokguApplication/PostHomeViews/AllUsers/ProfileView.swift
@@ -169,7 +169,6 @@ struct ProfileView: View {
                                 await MainActor.run {
                                     KeychainManager.shared.delete("loggedInUser")
                                     KeychainManager.shared.delete("userPermit")
-                                    KeychainManager.shared.delete("faceIDEnabled")
                                     userPermit = 0
                                     phoneNumber = ""
                                     isLoggedIn = false


### PR DESCRIPTION
## Summary
- eliminate Face ID authentication option
- drop Keychain and plist references tied to Face ID

## Testing
- `swift build`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b787a76fb883319c40f1e487dc203f